### PR TITLE
Make serviceAbbreviation on Metadata an optional field

### DIFF
--- a/Sources/CoralToJSONServiceModel/Metadata.swift
+++ b/Sources/CoralToJSONServiceModel/Metadata.swift
@@ -27,7 +27,7 @@ public struct Metadata: Codable {
     public let globalEndpoint: String?
     public let jsonVersion: String?
     public let protocolName: String
-    public let serviceAbbreviation: String
+    public let serviceAbbreviation: String?
     public let serviceFullName: String
     public let serviceId: String?
     public let signatureVersion: String


### PR DESCRIPTION
*Issue: N/A

*Description of changes:*
In this PR, **serviceAbbreviation** field has been changed to an optional field.
**serviceAbbreviation** is an optional field and actually there are some APIs on aws-sdk-go such as [rds-data](https://github.com/aws/aws-sdk-go/blob/c4cc55674c9e5a6d4e1fcb86f3d8f7597d3980b2/models/apis/rds-data/2018-08-01/api-2.json), [apigateway](https://github.com/aws/aws-sdk-go/tree/c4cc55674c9e5a6d4e1fcb86f3d8f7597d3980b2/models/apis/apigateway/2015-07-09) and [cloudformation](https://github.com/aws/aws-sdk-go/blob/c4cc55674c9e5a6d4e1fcb86f3d8f7597d3980b2/models/apis/cloudformation/2010-05-15/api-2.json) in which **serviceAbbreviation** is not included.

If a new configuration which does not include `serviceAbbreviation` (e.g. rds-data) is newly added without this change, `swift run ...` will fail with an error like below.

```
Linking ./.build/x86_64-apple-macosx10.10/release/SmokeAWSGenerate
^@Fatal error: Error raised at top level: Swift.DecodingError.keyNotFound(CodingKeys(stringValue: "serviceAbbreviation", intValue: nil), Swift.DecodingError.Context(codingPath: [CodingKeys(stringValue: "metadata", intValue: nil)], debugDescription: "No value associated with key CodingKeys(stringValue: \"serviceAbbreviation\", intValue: nil) (\"serviceAbbreviation\").", underlyingError: nil)): file /BuildRoot/Library/Caches/com.apple.xbs/Sources/swiftlang_Fall2018/swiftlang_Fall2018-1000.11.42/src/swift/stdlib/public/core/ErrorType.swift, line 191
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.