### PR TITLE
Fix Sync APIs throw HTTPClientError rather than cause.

### DIFF
--- a/Sources/SmokeAWSModelGenerate/APIGatewayClientDelegate.swift
+++ b/Sources/SmokeAWSModelGenerate/APIGatewayClientDelegate.swift
@@ -174,11 +174,23 @@ public struct APIGatewayClientDelegate: ModelClientDelegate {
                     """
             case .async:
                 return """
+                    func innerCompletion(error: SmokeHTTPClient.HTTPClientError?) {
+                        if let error = error {
+                            if let typedError = error.cause as? \(baseName)Error {
+                                completion(typedError)
+                            } else {
+                                completion(error.cause.asUnrecognized\(baseName)Error())
+                            }
+                        } else {
+                            completion(nil)
+                        }
+                    }
+                    
                     _ = try \(httpClientName).executeAsyncRetriableWithoutOutput(
                         endpointPath: "/\\(stage)" + \(baseName)ModelOperations.\(functionName).operationPath,
                         httpMethod: .\(httpVerb),
                         input: requestInput,
-                        completion: completion,
+                        completion: innerCompletion,
                         invocationContext: invocationContext,
                         retryConfiguration: retryConfiguration,
                         retryOnError: retryOnErrorProvider)

--- a/Sources/SmokeAWSModelGenerate/AWSClientDelegate+addAWSClientOperationBody.swift
+++ b/Sources/SmokeAWSModelGenerate/AWSClientDelegate+addAWSClientOperationBody.swift
@@ -90,34 +90,26 @@ internal extension AWSClientDelegate {
         switch invokeType {
         case .sync:
             return """
-            return try \(httpClientName).executeSyncRetriableWithOutput(
-                endpointPath: "\(http.url)",
-                httpMethod: .\(http.verb),
-                input: requestInput,
-                invocationContext: invocationContext,
-                retryConfiguration: retryConfiguration,
-                retryOnError: retryOnErrorProvider)
+            do {
+                return try \(httpClientName).executeSyncRetriableWithOutput(
+                    endpointPath: "\(http.url)",
+                    httpMethod: .\(http.verb),
+                    input: requestInput,
+                    invocationContext: invocationContext,
+                    retryConfiguration: retryConfiguration,
+                    retryOnError: retryOnErrorProvider)
+            } catch {
+                let typedError: \(baseName)Error = error.asTypedError()
+                throw typedError
+            }
             """
         case .async:
             return """
-            func innerCompletion(result: Result<\(baseName)Model.\(outputType), SmokeHTTPClient.HTTPClientError>) {
-                switch result {
-                case .success(let payload):
-                    completion(.success(payload))
-                case .failure(let error):
-                    if let typedError = error.cause as? \(baseName)Error {
-                        completion(.failure(typedError))
-                    } else {
-                        completion(.failure(error.cause.asUnrecognized\(baseName)Error()))
-                    }
-                }
-            }
-            
-            _ = try \(httpClientName).executeAsyncRetriableWithOutput(
+            _ = try \(httpClientName).executeOperationAsyncRetriableWithOutput(
                 endpointPath: "\(http.url)",
                 httpMethod: .\(http.verb),
                 input: requestInput,
-                completion: innerCompletion,
+                completion: completion,
                 invocationContext: invocationContext,
                 retryConfiguration: retryConfiguration,
                 retryOnError: retryOnErrorProvider)
@@ -132,33 +124,26 @@ internal extension AWSClientDelegate {
         switch invokeType {
         case .sync:
             return """
-            try \(httpClientName).executeSyncRetriableWithoutOutput(
-                endpointPath: "\(http.url)",
-                httpMethod: .\(http.verb),
-                input: requestInput,
-                invocationContext: invocationContext,
-                retryConfiguration: retryConfiguration,
-                retryOnError: retryOnErrorProvider)
+            do {
+                try \(httpClientName).executeSyncRetriableWithoutOutput(
+                    endpointPath: "\(http.url)",
+                    httpMethod: .\(http.verb),
+                    input: requestInput,
+                    invocationContext: invocationContext,
+                    retryConfiguration: retryConfiguration,
+                    retryOnError: retryOnErrorProvider)
+            } catch {
+                let typedError: \(baseName)Error = error.asTypedError()
+                throw typedError
+            }
             """
         case .async:
             return """
-            func innerCompletion(error: SmokeHTTPClient.HTTPClientError?) {
-                if let error = error {
-                    if let typedError = error.cause as? \(baseName)Error {
-                        completion(typedError)
-                    } else {
-                        completion(error.cause.asUnrecognized\(baseName)Error())
-                    }
-                } else {
-                    completion(nil)
-                }
-            }
-            
-            _ = try \(httpClientName).executeAsyncRetriableWithoutOutput(
+            _ = try \(httpClientName).executeOperationAsyncRetriableWithoutOutput(
                 endpointPath: "\(http.url)",
                 httpMethod: .\(http.verb),
                 input: requestInput,
-                completion: innerCompletion,
+                completion: completion,
                 invocationContext: invocationContext,
                 retryConfiguration: retryConfiguration,
                 retryOnError: retryOnErrorProvider)

--- a/Sources/SmokeAWSModelGenerate/AWSClientDelegate+addAWSClientQueryOperationBody.swift
+++ b/Sources/SmokeAWSModelGenerate/AWSClientDelegate+addAWSClientQueryOperationBody.swift
@@ -92,34 +92,26 @@ internal extension AWSClientDelegate {
         switch invokeType {
         case .sync:
             return """
-            return try \(httpClientName).executeSyncRetriableWithOutput(
-                endpointPath: "\(http.url)",
-                httpMethod: .\(http.verb),
-                input: requestInput,
-                invocationContext: invocationContext,
-                retryConfiguration: retryConfiguration,
-                retryOnError: retryOnErrorProvider)
+            do {
+                return try \(httpClientName).executeSyncRetriableWithOutput(
+                    endpointPath: "\(http.url)",
+                    httpMethod: .\(http.verb),
+                    input: requestInput,
+                    invocationContext: invocationContext,
+                    retryConfiguration: retryConfiguration,
+                    retryOnError: retryOnErrorProvider)
+            } catch {
+                let typedError: \(baseName)Error = error.asTypedError()
+                throw typedError
+            }
             """
         case .async:
             return """
-            func innerCompletion(result: Result<\(baseName)Model.\(outputType), SmokeHTTPClient.HTTPClientError>) {
-                switch result {
-                case .success(let payload):
-                    completion(.success(payload))
-                case .failure(let error):
-                    if let typedError = error.cause as? \(baseName)Error {
-                        completion(.failure(typedError))
-                    } else {
-                        completion(.failure(error.cause.asUnrecognized\(baseName)Error()))
-                    }
-                }
-            }
-            
-            _ = try \(httpClientName).executeAsyncRetriableWithOutput(
+            _ = try \(httpClientName).executeOperationAsyncRetriableWithOutput(
                 endpointPath: "\(http.url)",
                 httpMethod: .\(http.verb),
                 input: requestInput,
-                completion: innerCompletion,
+                completion: completion,
                 invocationContext: invocationContext,
                 retryConfiguration: retryConfiguration,
                 retryOnError: retryOnErrorProvider)
@@ -134,33 +126,26 @@ internal extension AWSClientDelegate {
         switch invokeType {
         case .sync:
             return """
-            try \(httpClientName).executeSyncRetriableWithoutOutput(
-                endpointPath: "\(http.url)",
-                httpMethod: .\(http.verb),
-                input: requestInput,
-                invocationContext: invocationContext,
-                retryConfiguration: retryConfiguration,
-                retryOnError: retryOnErrorProvider)
+            do {
+                try \(httpClientName).executeSyncRetriableWithoutOutput(
+                    endpointPath: "\(http.url)",
+                    httpMethod: .\(http.verb),
+                    input: requestInput,
+                    invocationContext: invocationContext,
+                    retryConfiguration: retryConfiguration,
+                    retryOnError: retryOnErrorProvider)
+            } catch {
+                let typedError: \(baseName)Error = error.asTypedError()
+                throw typedError
+            }
             """
         case .async:
             return """
-            func innerCompletion(error: SmokeHTTPClient.HTTPClientError?) {
-                if let error = error {
-                    if let typedError = error.cause as? \(baseName)Error {
-                        completion(typedError)
-                    } else {
-                        completion(error.cause.asUnrecognized\(baseName)Error())
-                    }
-                } else {
-                    completion(nil)
-                }
-            }
-            
-            _ = try \(httpClientName).executeAsyncRetriableWithoutOutput(
+            _ = try \(httpClientName).executeOperationAsyncRetriableWithoutOutput(
                 endpointPath: "\(http.url)",
                 httpMethod: .\(http.verb),
                 input: requestInput,
-                completion: innerCompletion,
+                completion: completion,
                 invocationContext: invocationContext,
                 retryConfiguration: retryConfiguration,
                 retryOnError: retryOnErrorProvider)

--- a/Sources/SmokeAWSModelGenerate/ModelClientDelegate+addAWSClientFileHeader.swift
+++ b/Sources/SmokeAWSModelGenerate/ModelClientDelegate+addAWSClientFileHeader.swift
@@ -130,7 +130,11 @@ extension ModelClientDelegate {
         
         fileBuilder.appendLine("""
             
-            internal extension \(errorType) {
+             extension \(errorType): ConvertableError {
+                public static func asUnrecognizedError(error: Swift.Error) -> \(errorType) {
+                    return error.asUnrecognized\(baseName)Error()
+                }
+            
                 func isRetriable() -> Bool {
             """)
         


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Fixes https://github.com/amzn/smoke-aws/issues/55 by getting the correctly typed error to be thrown by by *Sync APIs.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
