### PR TITLE
Add the ability to specify the InvocationTraceContext to use by default

### DIFF
--- a/Sources/SmokeAWSModelGenerate/APIGatewayClientDelegate.swift
+++ b/Sources/SmokeAWSModelGenerate/APIGatewayClientDelegate.swift
@@ -29,6 +29,7 @@ public struct APIGatewayClientDelegate: ModelClientDelegate {
     public let baseName: String
     public let contentType: String
     public let signAllHeaders: Bool
+    public let defaultInvocationTraceContext: InvocationTraceContextDeclaration
     
     private struct APIGatewayClientFunction {
         let name: String
@@ -46,7 +47,8 @@ public struct APIGatewayClientDelegate: ModelClientDelegate {
     public init(baseName: String,
                 asyncResultType: AsyncResultType? = nil,
                 contentType: String,
-                signAllHeaders: Bool) {
+                signAllHeaders: Bool,
+                defaultInvocationTraceContext: InvocationTraceContextDeclaration = InvocationTraceContextDeclaration(name: "AWSClientInvocationTraceContext")) {
         self.baseName = baseName
         self.asyncResultType = asyncResultType
         let genericParameters: [(String, String?)] = [("InvocationReportingType", "HTTPClientCoreInvocationReporting")]
@@ -54,6 +56,7 @@ public struct APIGatewayClientDelegate: ModelClientDelegate {
                                   conformingProtocolName: "\(baseName)ClientProtocol")
         self.contentType = contentType
         self.signAllHeaders = signAllHeaders
+        self.defaultInvocationTraceContext = defaultInvocationTraceContext
     }
     
     public func getFileDescription(isGenerator: Bool) -> String {
@@ -68,7 +71,8 @@ public struct APIGatewayClientDelegate: ModelClientDelegate {
                                     delegate: ModelClientDelegate,
                                     fileBuilder: FileBuilder,
                                     isGenerator: Bool) {
-        addAWSClientFileHeader(codeGenerator: codeGenerator, fileBuilder: fileBuilder, baseName: baseName, isGenerator: isGenerator)
+        addAWSClientFileHeader(codeGenerator: codeGenerator, fileBuilder: fileBuilder, baseName: baseName, isGenerator: isGenerator,
+                               defaultInvocationTraceContext: self.defaultInvocationTraceContext)
     }
     
     public func addCommonFunctions(codeGenerator: ServiceModelCodeGenerator,
@@ -81,7 +85,8 @@ public struct APIGatewayClientDelegate: ModelClientDelegate {
                                                    service: "execute-api",
                                                    target: nil,
                                                    contentType: contentType,
-                                                   globalEndpoint: nil)
+                                                   globalEndpoint: nil,
+                                                   defaultInvocationTraceContext: self.defaultInvocationTraceContext)
     
         addAWSClientCommonFunctions(fileBuilder: fileBuilder, baseName: baseName,
                                     clientAttributes: clientAttributes,

--- a/Sources/SmokeAWSModelGenerate/AWSClientAttributes.swift
+++ b/Sources/SmokeAWSModelGenerate/AWSClientAttributes.swift
@@ -18,6 +18,16 @@
 import Foundation
 import CoralToJSONServiceModel
 
+public struct InvocationTraceContextDeclaration {
+    public let name: String
+    public let importPackage: String?
+    
+    public init(name: String, importPackage: String? = nil) {
+        self.name = name
+        self.importPackage = importPackage
+    }
+}
+
 /**
  Structure that specifies the attributes of an AWS client.
  */
@@ -32,6 +42,8 @@ public struct AWSClientAttributes {
     public let contentType: String
     /// If the service has a global endpoint that should be used as its default endpoint.
     public let globalEndpoint: String?
+    /// The name of the InvocationTraceContext implementation to use.
+    public let defaultInvocationTraceContext: InvocationTraceContextDeclaration
     
     /**
      Initializer.
@@ -42,16 +54,19 @@ public struct AWSClientAttributes {
         - target: The service target this client is targeting.
         - contentType: The request content type used by this client.
         - globalEndpoint: If the service has a global endpoint that should be used as its default endpoint.
+        - defaultInvocationTraceContextName: The name of the InvocationTraceContext implementation to use.
      */
     public init(apiVersion: String,
                 service: String,
                 target: String?,
                 contentType: String,
-                globalEndpoint: String?) {
+                globalEndpoint: String?,
+                defaultInvocationTraceContext: InvocationTraceContextDeclaration = InvocationTraceContextDeclaration(name: "AWSClientInvocationTraceContext")) {
         self.apiVersion = apiVersion
         self.service = service
         self.target = target
         self.contentType = contentType
         self.globalEndpoint = globalEndpoint
+        self.defaultInvocationTraceContext = defaultInvocationTraceContext
     }
 }

--- a/Sources/SmokeAWSModelGenerate/AWSClientDelegate.swift
+++ b/Sources/SmokeAWSModelGenerate/AWSClientDelegate.swift
@@ -68,7 +68,8 @@ public struct AWSClientDelegate: ModelClientDelegate {
                                     delegate: ModelClientDelegate,
                                     fileBuilder: FileBuilder,
                                     isGenerator: Bool) {
-        addAWSClientFileHeader(codeGenerator: codeGenerator, fileBuilder: fileBuilder, baseName: baseName, isGenerator: isGenerator)
+        addAWSClientFileHeader(codeGenerator: codeGenerator, fileBuilder: fileBuilder, baseName: baseName, isGenerator: isGenerator,
+                               defaultInvocationTraceContext: self.clientAttributes.defaultInvocationTraceContext)
     }
     
     public func addCommonFunctions(codeGenerator: ServiceModelCodeGenerator,

--- a/Sources/SmokeAWSModelGenerate/ModelClientDelegate+addAWSClientFileHeader.swift
+++ b/Sources/SmokeAWSModelGenerate/ModelClientDelegate+addAWSClientFileHeader.swift
@@ -24,7 +24,7 @@ import CoralToJSONServiceModel
 extension ModelClientDelegate {
     func addAWSClientFileHeader(codeGenerator: ServiceModelCodeGenerator,
                                 fileBuilder: FileBuilder, baseName: String,
-                                isGenerator: Bool) {
+                                isGenerator: Bool, defaultInvocationTraceContext: InvocationTraceContextDeclaration) {
         fileBuilder.appendLine("""
             import SmokeAWSHttp
             import NIO
@@ -33,7 +33,13 @@ extension ModelClientDelegate {
             import Logging
             """)
         
-        if !isGenerator {
+        if isGenerator {
+            if let importPackage = defaultInvocationTraceContext.importPackage {
+                fileBuilder.appendLine("""
+                    import \(importPackage)
+                    """)
+            }
+        } else {
             fileBuilder.appendLine("""
                 
                 public enum \(baseName)ClientError: Swift.Error {

--- a/Sources/SmokeAWSModelGenerate/ModelClientDelegate+addAWSClientInitializer.swift
+++ b/Sources/SmokeAWSModelGenerate/ModelClientDelegate+addAWSClientInitializer.swift
@@ -528,13 +528,26 @@ extension ModelClientDelegate {
             """)
         }
     }
-    
+
     public func addAWSClientGeneratorWithReporting(
             fileBuilder: FileBuilder,
             baseName: String,
             codeGenerator: ServiceModelCodeGenerator,
             targetsAPIGateway: Bool,
             clientAttributes: AWSClientAttributes,
+            contentType: String) {
+        addAWSClientGeneratorWithReporting(fileBuilder: fileBuilder,
+                                           baseName: baseName,
+                                           codeGenerator: codeGenerator,
+                                           targetsAPIGateway: targetsAPIGateway,
+                                           contentType: contentType)
+    }
+ 
+    public func addAWSClientGeneratorWithReporting(
+            fileBuilder: FileBuilder,
+            baseName: String,
+            codeGenerator: ServiceModelCodeGenerator,
+            targetsAPIGateway: Bool,
             contentType: String) {
         guard case .struct(let clientName, _, _) = clientType else {
             fatalError()
@@ -588,13 +601,26 @@ extension ModelClientDelegate {
         }
         """)
     }
-    
+   
     public func addAWSClientGeneratorWithTraceContext(
             fileBuilder: FileBuilder,
             baseName: String,
             codeGenerator: ServiceModelCodeGenerator,
             targetsAPIGateway: Bool,
             clientAttributes: AWSClientAttributes,
+            contentType: String) {
+        addAWSClientGeneratorWithTraceContext(fileBuilder: fileBuilder,
+                                              baseName: baseName,
+                                              codeGenerator: codeGenerator,
+                                              targetsAPIGateway: targetsAPIGateway,
+                                              contentType: contentType)
+    }
+    
+    public func addAWSClientGeneratorWithTraceContext(
+            fileBuilder: FileBuilder,
+            baseName: String,
+            codeGenerator: ServiceModelCodeGenerator,
+            targetsAPIGateway: Bool,
             contentType: String) {
         guard case .struct(let clientName, _, _) = clientType else {
             fatalError()
@@ -623,6 +649,21 @@ extension ModelClientDelegate {
             targetsAPIGateway: Bool,
             clientAttributes: AWSClientAttributes,
             contentType: String) {
+        addAWSClientGeneratorWithLogger(fileBuilder: fileBuilder,
+                                        baseName: baseName,
+                                        codeGenerator: codeGenerator,
+                                        targetsAPIGateway: targetsAPIGateway,
+                                        invocationTraceContext: clientAttributes.defaultInvocationTraceContext,
+                                        contentType: contentType)
+    }
+    
+    public func addAWSClientGeneratorWithLogger(
+            fileBuilder: FileBuilder,
+            baseName: String,
+            codeGenerator: ServiceModelCodeGenerator,
+            targetsAPIGateway: Bool,
+            invocationTraceContext: InvocationTraceContextDeclaration,
+            contentType: String) {
         guard case .struct(let clientName, _, _) = clientType else {
             fatalError()
         }
@@ -631,11 +672,11 @@ extension ModelClientDelegate {
             
             public func with(
                     logger: Logging.Logger,
-                    internalRequestId: String = "none") -> \(clientName)<StandardHTTPClientCoreInvocationReporting<AWSClientInvocationTraceContext>> {
+                    internalRequestId: String = "none") -> \(clientName)<StandardHTTPClientCoreInvocationReporting<\(invocationTraceContext.name)>> {
                 let reporting = StandardHTTPClientCoreInvocationReporting(
                     logger: logger,
                     internalRequestId: internalRequestId,
-                    traceContext: AWSClientInvocationTraceContext())
+                    traceContext: \(invocationTraceContext.name)())
                 
                 return with(reporting: reporting)
             }

--- a/Sources/SmokeAWSModelGenerate/ModelClientDelegate+commonAWSFunctions.swift
+++ b/Sources/SmokeAWSModelGenerate/ModelClientDelegate+commonAWSFunctions.swift
@@ -50,17 +50,17 @@ extension ModelClientDelegate {
             addAWSClientGeneratorWithReporting(
                 fileBuilder: fileBuilder, baseName: baseName,
                 codeGenerator: codeGenerator, targetsAPIGateway: targetsAPIGateway,
-                clientAttributes: clientAttributes, contentType: contentType)
+                contentType: contentType)
             
             addAWSClientGeneratorWithTraceContext(
                 fileBuilder: fileBuilder, baseName: baseName,
                 codeGenerator: codeGenerator, targetsAPIGateway: targetsAPIGateway,
-                clientAttributes: clientAttributes, contentType: contentType)
+                contentType: contentType)
             
-            addAWSClientGeneratorWithAWSTraceContext(
+            addAWSClientGeneratorWithLogger(
                 fileBuilder: fileBuilder, baseName: baseName,
                 codeGenerator: codeGenerator, targetsAPIGateway: targetsAPIGateway,
-                clientAttributes: clientAttributes, contentType: contentType)
+                invocationTraceContext: clientAttributes.defaultInvocationTraceContext, contentType: contentType)
         }
     }
 }


### PR DESCRIPTION

*Issue #, if available:*

*Description of changes:* Add the ability to specify the InvocationTraceContext to use by default with the generator's with(logger:) variant.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
