### PR TITLE
Don't fail decoding if JSON error type is not present. 

### DIFF
--- a/Sources/SmokeAWSGenerate/CodePipelineConfiguration.swift
+++ b/Sources/SmokeAWSGenerate/CodePipelineConfiguration.swift
@@ -29,7 +29,9 @@ internal struct CodePipelineConfiguration {
                                                               "PipelineExecutionStatus",
                                                               "StageExecutionStatus",
                                                               "TriggerType"]
-        ))
+        ),
+        fieldRawTypeOverride:
+            [Fields.timestamp.typeDescription: CommonConfiguration.integerDateOverride])
     
     static let httpClientConfiguration = HttpClientConfiguration(
         retryOnUnknownError: true,

--- a/Sources/SmokeAWSGenerate/main.swift
+++ b/Sources/SmokeAWSGenerate/main.swift
@@ -36,7 +36,7 @@ struct CommonConfiguration {
 }
 
 var isUsage = CommandLine.arguments.count == 2 && CommandLine.arguments[1] == "--help"
-let goRepositoryTag = "v1.38.57"
+let goRepositoryTag = "v1.41.0"
 
 let fileHeader = """
     // Copyright 2018-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
@@ -171,12 +171,12 @@ func generatePackageFile(baseNames: [String]) -> String {
                     targets: ["SmokeAWSMetrics"]),
             ],
             dependencies: [
-                .package(url: "https://github.com/apple/swift-nio.git", from: "2.0.0"),
-                .package(url: "https://github.com/apple/swift-nio-ssl.git", from: "2.0.0"),
+                .package(url: "https://github.com/apple/swift-nio.git", from: "2.33.0"),
+                .package(url: "https://github.com/apple/swift-nio-ssl.git", from: "2.14.0"),
                 .package(url: "https://github.com/apple/swift-log", from: "1.0.0"),
                 .package(url: "https://github.com/apple/swift-metrics.git", "1.0.0"..<"3.0.0"),
                 .package(url: "https://github.com/LiveUI/XMLCoding.git", from: "0.4.1"),
-                .package(url: "https://github.com/amzn/smoke-http.git", from: "2.8.0"),
+                .package(url: "https://github.com/amzn/smoke-http.git", from: "2.9.0"),
                 .package(url: "https://github.com/apple/swift-crypto.git", from: "1.0.0"),
             ],
             targets: [\n
@@ -209,7 +209,6 @@ func generatePackageFile(baseNames: [String]) -> String {
                 .target(
                     name: "_SmokeAWSHttpConcurrency", dependencies: [
                         .target(name: "SmokeAWSHttp"),
-                        .product(name: "_SmokeHTTPClientConcurrency", package: "smoke-http"),
                     ]),
                 .target(
                     name: "SmokeAWSMetrics", dependencies: [
@@ -352,7 +351,7 @@ func handleApplication() throws {
         RDSDataConfiguration.serviceModelDetails,
         // disabled; currently untested
         //CodeBuildConfiguration.serviceModelDetails,
-        //CodePipelineConfiguration.serviceModelDetails,
+        CodePipelineConfiguration.serviceModelDetails,
         ECRConfiguration.serviceModelDetails]
     
     var baseFilePath: String?

--- a/Sources/SmokeAWSModelGenerate/AWSModelErrorsDelegate.swift
+++ b/Sources/SmokeAWSModelGenerate/AWSModelErrorsDelegate.swift
@@ -98,9 +98,17 @@ struct AWSModelErrorsDelegate: ModelErrorsDelegate {
     
     func errorTypeIdentityGenerator(fileBuilder: FileBuilder,
                                     codingErrorUnknownError: String) -> String {
+        let errorReasonRetrievalBody: String
+        switch awsClientAttributes.contentType.contentTypePayloadType {
+        case .xml:
+            errorReasonRetrievalBody = "try values.decode(String.self, forKey: .type)"
+        case .json:
+            errorReasonRetrievalBody = "try values.decodeIfPresent(String.self, forKey: .type) ?? \"Unspecified\""
+        }
+        
         fileBuilder.appendLine("""
             let values = try decoder.container(keyedBy: CodingKeys.self)
-            var errorReason = try values.decode(String.self, forKey: .type)
+            var errorReason = \(errorReasonRetrievalBody)
             let errorMessage = try values.decodeIfPresent(String.self, forKey: .message)
 
             if let index = errorReason.firstIndex(of: "#") {


### PR DESCRIPTION
…ne client.

*Issue #, if available:*
1. Don't fail decoding if JSON error type is not present. 
2. 2. Add CodePipeline client.

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
