### PR TITLE
Add AWS AppConfig client

### DIFF
--- a/Sources/SmokeAWSGenerate/AppConfigConfiguration.swift
+++ b/Sources/SmokeAWSGenerate/AppConfigConfiguration.swift
@@ -1,0 +1,49 @@
+// Copyright 2019-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// A copy of the License is located at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// AppConfigConfiguration.swift
+// SmokeAWSGenerate
+//
+
+import Foundation
+import ServiceModelEntities
+
+private let errorTypeHTTPHeaderName = "x-amzn-ErrorType"
+
+internal struct AppConfigConfiguration {
+    static let modelOverride = ModelOverride(
+        namedFieldOverride: ["Tags": "[:] as [String:String]"],
+        codingKeyOverrides: ["AppConfigError.message": "Message"],
+        additionalErrors: ["AccessDeniedException"])
+    
+    static let additionalHttpClient = AdditionalHttpClient(
+        clientDelegateNameOverride: "DataAWSHttpClientDelegate",
+        clientDelegateParameters: ["errorTypeHTTPHeader: \"\(errorTypeHTTPHeaderName)\""],
+        operations: ["GetConfiguration", "GetHostedConfigurationVersion"])
+    
+    static let httpClientConfiguration = HttpClientConfiguration(
+        retryOnUnknownError: true,
+        knownErrorsDefaultRetryBehavior: .fail,
+        unretriableUnknownErrors: [],
+        retriableUnknownErrors: [],
+        clientDelegateParameters: ["errorTypeHTTPHeader: \"\(errorTypeHTTPHeaderName)\""],
+        additionalClients: ["dataHttpClient": additionalHttpClient])
+    
+    static let serviceModelDetails = ServiceModelDetails(
+        serviceName: "appconfig",
+        serviceVersion: "2019-10-09",
+        baseName: "AppConfig",
+        modelOverride: modelOverride,
+        httpClientConfiguration: httpClientConfiguration,
+        signAllHeaders: false)
+}

--- a/Sources/SmokeAWSGenerate/main.swift
+++ b/Sources/SmokeAWSGenerate/main.swift
@@ -240,6 +240,10 @@ func generatePackageFile(baseNames: [String]) -> String {
                     name: "RDSClientTests", dependencies: [
                         .target(name: "RDSClient"),
                     ]),
+                .testTarget(
+                    name: "AppConfigClientTests", dependencies: [
+                        .target(name: "AppConfigClient"),
+                    ]),
             ],
             swiftLanguageVersions: [.v5]
         )
@@ -352,7 +356,8 @@ func handleApplication() throws {
         // disabled; currently untested
         //CodeBuildConfiguration.serviceModelDetails,
         CodePipelineConfiguration.serviceModelDetails,
-        ECRConfiguration.serviceModelDetails]
+        ECRConfiguration.serviceModelDetails,
+        AppConfigConfiguration.serviceModelDetails]
     
     var baseFilePath: String?
     var missingOptions: Set<String> = [baseFilePathOption]

--- a/Sources/SmokeAWSModelGenerate/AWSModelErrorsDelegate.swift
+++ b/Sources/SmokeAWSModelGenerate/AWSModelErrorsDelegate.swift
@@ -25,6 +25,8 @@ struct AWSModelErrorsDelegate: ModelErrorsDelegate {
     let generateCustomStringConvertibleConformance: Bool = false
     let canExpectValidationError: Bool = false
     let awsClientAttributes: AWSClientAttributes
+    let modelOverride: ModelOverride?
+    let baseName: String
     
     func addAccessDeniedError(errorTypes: [ErrorType]) -> Bool {
         for error in errorTypes where error.normalizedName == "accessDenied" {
@@ -76,8 +78,8 @@ struct AWSModelErrorsDelegate: ModelErrorsDelegate {
     
     func errorTypeCodingKeysGenerator(fileBuilder: FileBuilder,
                                       errorTypes: [ErrorType]) {
-        let typeCodingKey: String
-        let messageCodingKey: String
+        var typeCodingKey: String
+        var messageCodingKey: String
         
         switch awsClientAttributes.contentType.contentTypePayloadType {
         case .xml:
@@ -86,6 +88,11 @@ struct AWSModelErrorsDelegate: ModelErrorsDelegate {
         case .json:
             typeCodingKey = "__type"
             messageCodingKey = "message"
+        }
+        
+        if let codingKeyOverrides = modelOverride?.codingKeyOverrides {
+            typeCodingKey = codingKeyOverrides["\(baseName)Error.type"] ?? typeCodingKey
+            messageCodingKey = codingKeyOverrides["\(baseName)Error.message"] ?? messageCodingKey
         }
     
         fileBuilder.appendLine("""

--- a/Sources/SmokeAWSModelGenerate/SmokeAWSModelGenerate.swift
+++ b/Sources/SmokeAWSModelGenerate/SmokeAWSModelGenerate.swift
@@ -65,7 +65,9 @@ extension ServiceModelCodeGenerator {
             baseName: applicationDescription.baseName,
             clientAttributes: awsClientAttributes,
             signAllHeaders: signAllHeaders)
-        let awsModelErrorsDelegate = AWSModelErrorsDelegate(awsClientAttributes: awsClientAttributes)
+        let awsModelErrorsDelegate = AWSModelErrorsDelegate(awsClientAttributes: awsClientAttributes,
+                                                            modelOverride: modelOverride,
+                                                            baseName: applicationDescription.baseName)
         
         generateClient(delegate: clientProtocolDelegate, isGenerator: false)
         generateClient(delegate: mockClientDelegate, isGenerator: false)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Add code generation for AWS AppConfig client.
Allow override of model error type coding keys.
Allow client configurations to specify an HTTP header that contains the error type in an error HTTP response.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
