### PR TITLE
Fix timestamp type for ECS.

### DIFF
--- a/Sources/SmokeAWSGenerate/ECSConfiguration.swift
+++ b/Sources/SmokeAWSGenerate/ECSConfiguration.swift
@@ -19,7 +19,9 @@ import Foundation
 import ServiceModelEntities
 
 internal struct ECSConfiguration {
-    static let modelOverride = ModelOverride(fieldRawTypeOverride: ["Long": CommonConfiguration.intOverride])
+    static let modelOverride = ModelOverride(fieldRawTypeOverride:
+                                                [Fields.timestamp.typeDescription: CommonConfiguration.integerDateOverride,
+                                                 "Long": CommonConfiguration.intOverride])
 
     static let httpClientConfiguration = HttpClientConfiguration(
         retryOnUnknownError: true,

--- a/Sources/SmokeAWSGenerate/main.swift
+++ b/Sources/SmokeAWSGenerate/main.swift
@@ -36,7 +36,7 @@ struct CommonConfiguration {
 }
 
 var isUsage = CommandLine.arguments.count == 2 && CommandLine.arguments[1] == "--help"
-let goRepositoryTag = "v1.42.12"
+let goRepositoryTag = "v1.42.44"
 
 let fileHeader = """
     // Copyright 2018-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Correctly generates ECS timestamps as doubles rather than strings.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
