### PR TITLE
Generate error option set for APIGateway clients

### DIFF
--- a/Sources/APIGatewayClientModelGenerate/APIGatewayClientModelErrorsDelegate.swift
+++ b/Sources/APIGatewayClientModelGenerate/APIGatewayClientModelErrorsDelegate.swift
@@ -20,7 +20,7 @@ import ServiceModelCodeGeneration
 import ServiceModelEntities
 
 struct APIGatewayClientModelErrorsDelegate: ModelErrorsDelegate {
-    let optionSetGeneration: ErrorOptionSetGeneration = .noGeneration
+    let optionSetGeneration: ErrorOptionSetGeneration = .generateWithCustomStringConvertibleConformance
     let generateEncodableConformance: Bool = false
     let generateCustomStringConvertibleConformance: Bool = false
     let canExpectValidationError: Bool = false


### PR DESCRIPTION


*Issue #, if available:* Generate error option set as it is now used by `(ServiceName)ModelOperations.allowedErrors`

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
