### PR TITLE
Create an untypedError if there is no error type.

### DIFF
--- a/Sources/APIGatewayClientModelGenerate/APIGatewayClientModelErrorsDelegate.swift
+++ b/Sources/APIGatewayClientModelGenerate/APIGatewayClientModelErrorsDelegate.swift
@@ -44,7 +44,8 @@ struct APIGatewayClientModelErrorsDelegate: ModelErrorsDelegate {
                                                 errorTypes: [ErrorType]) {
         fileBuilder.appendLine("""
         case validationError(reason: String)
-        case unrecognizedError(String?, String?)
+        case unrecognizedError(String, String?)
+        case untypedError(String?)
         """)
     }
     
@@ -73,7 +74,7 @@ struct APIGatewayClientModelErrorsDelegate: ModelErrorsDelegate {
                     errorReason = type
                 }
             } else {
-                self = .unrecognizedError(nil, errorMessage)
+                self = .untypedError(errorMessage)
                 return
             }
             """)

--- a/Sources/SmokeAWSModelGenerate/AWSModelErrorsDelegate.swift
+++ b/Sources/SmokeAWSModelGenerate/AWSModelErrorsDelegate.swift
@@ -70,7 +70,8 @@ struct AWSModelErrorsDelegate: ModelErrorsDelegate {
         
         fileBuilder.appendLine("""
         case validationError(reason: String)
-        case unrecognizedError(String?, String?)
+        case unrecognizedError(String, String?)
+        case untypedError(String?)
         """)
     }
     
@@ -111,7 +112,7 @@ struct AWSModelErrorsDelegate: ModelErrorsDelegate {
                     errorReason = type
                 }
             } else {
-                self = .unrecognizedError(nil, errorMessage)
+                self = .untypedError(errorMessage)
                 return
             }
             """)

--- a/Sources/SmokeAWSModelGenerate/AWSModelErrorsDelegate.swift
+++ b/Sources/SmokeAWSModelGenerate/AWSModelErrorsDelegate.swift
@@ -70,7 +70,7 @@ struct AWSModelErrorsDelegate: ModelErrorsDelegate {
         
         fileBuilder.appendLine("""
         case validationError(reason: String)
-        case unrecognizedError(String, String?)
+        case unrecognizedError(String?, String?)
         """)
     }
     
@@ -100,11 +100,19 @@ struct AWSModelErrorsDelegate: ModelErrorsDelegate {
                                     codingErrorUnknownError: String) -> String {
         fileBuilder.appendLine("""
             let values = try decoder.container(keyedBy: CodingKeys.self)
-            var errorReason = try values.decode(String.self, forKey: .type)
+            let type = try values.decodeIfPresent(String.self, forKey: .type)
             let errorMessage = try values.decodeIfPresent(String.self, forKey: .message)
-
-            if let index = errorReason.firstIndex(of: "#") {
-                errorReason = String(errorReason[errorReason.index(index, offsetBy: 1)...])
+            
+            let errorReason: String
+            if let type = type {
+                if let index = type.firstIndex(of: "#") {
+                    errorReason = String(type[type.index(index, offsetBy: 1)...])
+                } else {
+                    errorReason = type
+                }
+            } else {
+                self = .unrecognizedError(nil, errorMessage)
+                return
             }
             """)
         


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Create an untypedError if there is no error type rather than failing with a deserialisation error.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
