### PR TITLE
Generate Shape protocol for structs created for API Gateway client

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/amzn/service-model-swift-code-generate.git",
         "state": {
           "branch": null,
-          "revision": "286181816fccc2b6ec92049ba68426d08cbe0059",
-          "version": "3.0.0-beta.1"
+          "revision": "8b785a96df729cd245685ade37aea56ba3599c7a",
+          "version": "3.0.0-beta.3"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -39,7 +39,7 @@ let package = Package(
     ],
     dependencies: [
         .package(name: "ServiceModelSwiftCodeGenerate",
-                 url: "https://github.com/amzn/service-model-swift-code-generate.git", from: "3.0.0-beta.1"),
+                 url: "https://github.com/amzn/service-model-swift-code-generate.git", from: "3.0.0-beta.3"),
         .package(url: "https://github.com/apple/swift-argument-parser", from: "0.3.0"),
     ],
     targets: [

--- a/Sources/APIGatewayClientGenerate/main.swift
+++ b/Sources/APIGatewayClientGenerate/main.swift
@@ -169,7 +169,7 @@ func handleApplication() throws {
                 validationErrorDeclaration: validationErrorDeclaration,
                 unrecognizedErrorDeclaration: unrecognizedErrorDeclaration,
                 asyncAwaitAPIs: .enabled,
-                generateModelShapeConversions: false,
+                generateModelShapeConversions: true,
                 optionalsInitializeEmpty: true,
                 fileHeader: nil,
                 httpClientConfiguration: httpClientConfiguration)

--- a/Sources/APIGatewayClientModelGenerate/ServiceModelCodeGeneration+generateServerApplicationFiles.swift
+++ b/Sources/APIGatewayClientModelGenerate/ServiceModelCodeGeneration+generateServerApplicationFiles.swift
@@ -35,7 +35,7 @@ extension ServiceModelCodeGenerator {
         let baseFilePath = applicationDescription.baseFilePath
         
         fileBuilder.appendLine("""
-            // swift-tools-version:5.2
+            // swift-tools-version:5.3
             """)
         
         if let fileHeader = customizations.fileHeader {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Generate Shape protocol for structs created for API Gateway client. This also updated the `swift-tools-version` of the generated Package.swift file to 5.3, the minimum tested version in smoke-aws.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
