### PR TITLE
Customize SNS client to support large messages

### DIFF
--- a/Sources/SmokeAWSGenerate/SNSConfiguration.swift
+++ b/Sources/SmokeAWSGenerate/SNSConfiguration.swift
@@ -17,6 +17,7 @@
 
 import Foundation
 import ServiceModelEntities
+import SmokeAWSModelGenerate
 
 internal struct SNSConfiguration {
     static let modelOverride = ModelOverride(
@@ -44,11 +45,16 @@ internal struct SNSConfiguration {
         unretriableUnknownErrors: [],
         retriableUnknownErrors: ["FilterPolicyLimitExceededException", "KMSThrottlingException",
                                  "SubscriptionLimitExceededException", "ThrottledException",
-                                 "TopicLimitExceededException"])
+                                 "TopicLimitExceededException"],
+        clientDelegateNameOverride: "FormEncodedXMLAWSHttpClientDelegate")
     
     static let serviceModelDetails = ServiceModelDetails(
-        serviceName: "sns", serviceVersion: "2010-03-31",
-        baseName: "SimpleNotification", modelOverride: modelOverride,
+        serviceName: "sns",
+        serviceVersion: "2010-03-31",
+        baseName: "SimpleNotification",
+        modelOverride: modelOverride,
         httpClientConfiguration: httpClientConfiguration,
-        signAllHeaders: false)
+        signAllHeaders: false,
+        awsCodeGenerationCustomizations: AWSCodeGenerationCustomizations(
+            contentTypeHeaderOverride: "application/x-www-form-urlencoded; charset=utf-8"))
 }

--- a/Sources/SmokeAWSGenerate/main.swift
+++ b/Sources/SmokeAWSGenerate/main.swift
@@ -260,6 +260,23 @@ struct ServiceModelDetails {
     let modelOverride: ModelOverride?
     let httpClientConfiguration: HttpClientConfiguration
     let signAllHeaders: Bool
+    let awsCodeGenerationCustomizations: AWSCodeGenerationCustomizations
+
+    init(serviceName: String,
+         serviceVersion: String,
+         baseName: String,
+         modelOverride: ModelOverride?,
+         httpClientConfiguration: HttpClientConfiguration,
+         signAllHeaders: Bool,
+         awsCodeGenerationCustomizations: AWSCodeGenerationCustomizations = AWSCodeGenerationCustomizations(contentTypeHeaderOverride: nil)) {
+        self.serviceName = serviceName
+        self.serviceVersion = serviceVersion
+        self.baseName = baseName
+        self.modelOverride = modelOverride
+        self.httpClientConfiguration = httpClientConfiguration
+        self.signAllHeaders = signAllHeaders
+        self.awsCodeGenerationCustomizations = awsCodeGenerationCustomizations
+    }
 }
 
 private func generateSmokeAWS(tempDirURL: URL,
@@ -306,6 +323,7 @@ private func generateSmokeAWS(tempDirURL: URL,
         try SmokeAWSModelGenerate.generateFromModel(
             modelFilePath: modelFilePath,
             customizations: customizations,
+            awsCustomizations: details.awsCodeGenerationCustomizations,
             applicationDescription: fullApplicationDescription,
             modelOverride: details.modelOverride,
             signAllHeaders: details.signAllHeaders)

--- a/Sources/SmokeAWSModelGenerate/APIGatewayClientDelegate.swift
+++ b/Sources/SmokeAWSModelGenerate/APIGatewayClientDelegate.swift
@@ -93,7 +93,10 @@ public struct APIGatewayClientDelegate: ModelClientDelegate {
                                     codeGenerator: codeGenerator,
                                     targetsAPIGateway: true,
                                     contentType: contentType,
-                                    sortedOperations: sortedOperations, isGenerator: isGenerator)
+                                    sortedOperations: sortedOperations,
+                                    isGenerator: isGenerator,
+                                    awsCustomization: AWSCodeGenerationCustomizations(
+                                        contentTypeHeaderOverride: nil))
     }
     
     public func addOperationBody(codeGenerator: ServiceModelCodeGenerator,

--- a/Sources/SmokeAWSModelGenerate/AWSClientDelegate.swift
+++ b/Sources/SmokeAWSModelGenerate/AWSClientDelegate.swift
@@ -29,6 +29,7 @@ public struct AWSClientDelegate: ModelClientDelegate {
     public let asyncResultType: AsyncResultType?
     public let baseName: String
     public let signAllHeaders: Bool
+    public let awsCustomizations: AWSCodeGenerationCustomizations
     
     struct AWSClientFunction {
         let name: String
@@ -46,7 +47,8 @@ public struct AWSClientDelegate: ModelClientDelegate {
     public init(baseName: String,
                 clientAttributes: AWSClientAttributes,
                 signAllHeaders: Bool,
-                asyncResultType: AsyncResultType? = nil) {
+                asyncResultType: AsyncResultType? = nil,
+                awsCustomizations: AWSCodeGenerationCustomizations) {
         self.baseName = baseName
         self.clientAttributes = clientAttributes
         self.asyncResultType = asyncResultType
@@ -54,6 +56,7 @@ public struct AWSClientDelegate: ModelClientDelegate {
         self.clientType = .struct(name: "AWS\(baseName)Client", genericParameters: genericParameters,
                                   conformingProtocolName: "\(baseName)ClientProtocol")
         self.signAllHeaders = signAllHeaders
+        self.awsCustomizations = awsCustomizations
     }
     
     public func getFileDescription(isGenerator: Bool) -> String {
@@ -82,7 +85,9 @@ public struct AWSClientDelegate: ModelClientDelegate {
                                     codeGenerator: codeGenerator,
                                     targetsAPIGateway: false,
                                     contentType: clientAttributes.contentType,
-                                    sortedOperations: sortedOperations, isGenerator: isGenerator)
+                                    sortedOperations: sortedOperations,
+                                    isGenerator: isGenerator,
+                                    awsCustomization: self.awsCustomizations)
     }
     
     public func addOperationBody(codeGenerator: ServiceModelCodeGenerator,

--- a/Sources/SmokeAWSModelGenerate/AWSCodeGenerationCustomizations.swift
+++ b/Sources/SmokeAWSModelGenerate/AWSCodeGenerationCustomizations.swift
@@ -1,0 +1,30 @@
+// Copyright 2019-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// A copy of the License is located at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// AWSCodeGenerationCustomizations.swift
+// SmokeAWSModelGenerate
+//
+
+import Foundation
+
+/**
+ Specifies customizations to the AWS code generation.
+ */
+public struct AWSCodeGenerationCustomizations {
+    /// Value of the content-type header.
+    public let contentTypeHeaderOverride: String?
+
+    public init(contentTypeHeaderOverride: String?) {
+        self.contentTypeHeaderOverride = contentTypeHeaderOverride
+    }
+}

--- a/Sources/SmokeAWSModelGenerate/ModelClientDelegate+addAWSClientInitializer.swift
+++ b/Sources/SmokeAWSModelGenerate/ModelClientDelegate+addAWSClientInitializer.swift
@@ -28,7 +28,8 @@ extension ModelClientDelegate {
                                            targetsAPIGateway: Bool,
                                            contentType: String,
                                            sortedOperations: [(String, OperationDescription)],
-                                           isGenerator: Bool) {
+                                           isGenerator: Bool,
+                                           awsCustomization: AWSCodeGenerationCustomizations) {
         let targetValue: String
         if let target = clientAttributes.target {
             targetValue = "\"\(target)\""
@@ -56,7 +57,7 @@ extension ModelClientDelegate {
         let targetOrVersionParameterCopyConstructor: String
         let targetAssignment: String
         let contentTypeAssignment: String
-        
+
         // Use a specific initializer for queries
         switch contentType.contentTypeDefaultInputLocation {
         case .query:
@@ -70,8 +71,12 @@ extension ModelClientDelegate {
             targetOrVersionParameterCopyConstructor = "apiVersion: String"
             targetAssignment = "self.target = nil"
             
-            // use 'application/octet-stream' as the content type
-            contentTypeAssignment = "contentType: String = \"application/octet-stream\""
+            // use 'application/octet-stream' as the content type unless specified otherwise
+            if let contentTypeHeaderOverride = awsCustomization.contentTypeHeaderOverride {
+                contentTypeAssignment = "contentType: String = \"\(contentTypeHeaderOverride)\""
+            } else {
+                contentTypeAssignment = "contentType: String = \"application/octet-stream\""
+            }
         case .body:
             addAWSClientBodyMembers(
                 fileBuilder: fileBuilder,
@@ -84,7 +89,11 @@ extension ModelClientDelegate {
             targetAssignment = "self.target = target"
             
             // use the content type from the client attributes as the default
-            contentTypeAssignment = "contentType: String = \"\(clientAttributes.contentType)\""
+            if let contentTypeHeaderOverride = awsCustomization.contentTypeHeaderOverride {
+                contentTypeAssignment = "contentType: String = \"\(contentTypeHeaderOverride)\""
+            } else {
+                contentTypeAssignment = "contentType: String = \"\(clientAttributes.contentType)\""
+            }
         }
         
         fileBuilder.appendEmptyLine()

--- a/Sources/SmokeAWSModelGenerate/ModelClientDelegate+commonAWSFunctions.swift
+++ b/Sources/SmokeAWSModelGenerate/ModelClientDelegate+commonAWSFunctions.swift
@@ -28,7 +28,8 @@ extension ModelClientDelegate {
                                      targetsAPIGateway: Bool,
                                      contentType: String,
                                      sortedOperations: [(String, OperationDescription)],
-                                     isGenerator: Bool) {
+                                     isGenerator: Bool,
+                                     awsCustomization: AWSCodeGenerationCustomizations) {
         addAWSClientInitializerAndMembers(fileBuilder: fileBuilder,
                                           baseName: baseName,
                                           clientAttributes: clientAttributes,
@@ -36,7 +37,8 @@ extension ModelClientDelegate {
                                           targetsAPIGateway: targetsAPIGateway,
                                           contentType: contentType,
                                           sortedOperations: sortedOperations,
-                                          isGenerator: isGenerator)
+                                          isGenerator: isGenerator,
+                                          awsCustomization: awsCustomization)
         
         addAWSClientDeinitializer(fileBuilder: fileBuilder,
                                   baseName: baseName,

--- a/Sources/SmokeAWSModelGenerate/SmokeAWSModelGenerate.swift
+++ b/Sources/SmokeAWSModelGenerate/SmokeAWSModelGenerate.swift
@@ -26,6 +26,7 @@ public struct SmokeAWSModelGenerate {
     public static func generateFromModel(
         modelFilePath: String,
         customizations: CodeGenerationCustomizations,
+        awsCustomizations: AWSCodeGenerationCustomizations,
         applicationDescription: ApplicationDescription,
         modelOverride: ModelOverride?,
         signAllHeaders: Bool) throws {
@@ -33,8 +34,8 @@ public struct SmokeAWSModelGenerate {
                                    serviceModel: CoralToJSONServiceModel) throws {
                 try codeGenerator.generateFromCoralToJSONServiceModel(
                     coralToJSONServiceModel: serviceModel,
-                    signAllHeaders: signAllHeaders
-                )
+                    signAllHeaders: signAllHeaders,
+                    awsCustomizations: awsCustomizations)
             }
         
             try ServiceModelGenerate.generateFromModel(
@@ -50,7 +51,8 @@ extension ServiceModelCodeGenerator {
     
     func generateFromCoralToJSONServiceModel(
             coralToJSONServiceModel: CoralToJSONServiceModel,
-            signAllHeaders: Bool) throws {
+            signAllHeaders: Bool,
+            awsCustomizations: AWSCodeGenerationCustomizations) throws {
         let awsClientAttributes = coralToJSONServiceModel.getAWSClientAttributes()
         
         let clientProtocolDelegate = ClientProtocolDelegate(
@@ -64,7 +66,8 @@ extension ServiceModelCodeGenerator {
         let awsClientDelegate = AWSClientDelegate(
             baseName: applicationDescription.baseName,
             clientAttributes: awsClientAttributes,
-            signAllHeaders: signAllHeaders)
+            signAllHeaders: signAllHeaders,
+            awsCustomizations: awsCustomizations)
         let awsModelErrorsDelegate = AWSModelErrorsDelegate(awsClientAttributes: awsClientAttributes,
                                                             modelOverride: modelOverride,
                                                             baseName: applicationDescription.baseName)


### PR DESCRIPTION
This is a follow up to the https://github.com/amzn/smoke-aws/pull/121

This update introduces two things:
* The package is updated to customize AWS clients content-type header
* SNS client is updated to use `FormEncodedXMLAWSHttpClientDelegate` that encodes query parameters into request body
* SNS client is updated to use `application/x-www-form-urlencoded; charset=utf-8` which goes hand-in-hand with `FormEncodedXMLAWSHttpClientDelegate`

This collectively creates an SNS client that can send messages larger than ~16KB.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
