### PR TITLE
Use Generic Client Name with Client Generator

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -44,7 +44,7 @@ let package = Package(
             targets: ["APIGatewaySwiftGenerateClient"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/amzn/service-model-swift-code-generate.git", from: "3.0.0-beta.5"),
+        .package(url: "https://github.com/amzn/service-model-swift-code-generate.git", from: "3.0.0-beta.7"),
         .package(url: "https://github.com/apple/swift-argument-parser", from: "0.3.0"),
     ],
     targets: [

--- a/Sources/SmokeAWSModelGenerate/ModelClientDelegate+addAWSClientInitializer.swift
+++ b/Sources/SmokeAWSModelGenerate/ModelClientDelegate+addAWSClientInitializer.swift
@@ -1137,8 +1137,8 @@ extension ModelClientDelegate {
         fileBuilder.appendLine("""
             
             public func with<NewInvocationReportingType: HTTPClientCoreInvocationReporting>(
-                    reporting: NewInvocationReportingType) -> \(clientName)<NewInvocationReportingType> {
-                return \(clientName)<NewInvocationReportingType>(
+                    reporting: NewInvocationReportingType) -> Generic\(clientName)<NewInvocationReportingType> {
+                return Generic\(clientName)<NewInvocationReportingType>(
                     credentialsProvider: self.credentialsProvider,
                     awsRegion: self.awsRegion,
                     reporting: reporting,
@@ -1214,7 +1214,7 @@ extension ModelClientDelegate {
                     logger: Logging.Logger,
                     internalRequestId: String = "none",
                     traceContext: NewTraceContextType,
-                    eventLoop: EventLoop? = nil) -> \(clientName)<StandardHTTPClientCoreInvocationReporting<NewTraceContextType>> {
+                    eventLoop: EventLoop? = nil) -> Generic\(clientName)<StandardHTTPClientCoreInvocationReporting<NewTraceContextType>> {
                 let reporting = StandardHTTPClientCoreInvocationReporting(
                     logger: logger,
                     internalRequestId: internalRequestId,
@@ -1257,7 +1257,7 @@ extension ModelClientDelegate {
             public func with(
                     logger: Logging.Logger,
                     internalRequestId: String = "none",
-                    eventLoop: EventLoop? = nil) -> \(clientName)<StandardHTTPClientCoreInvocationReporting<\(invocationTraceContext.name)>> {
+                    eventLoop: EventLoop? = nil) -> Generic\(clientName)<StandardHTTPClientCoreInvocationReporting<\(invocationTraceContext.name)>> {
                 let reporting = StandardHTTPClientCoreInvocationReporting(
                     logger: logger,
                     internalRequestId: internalRequestId,


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This change fixes the error when using the `3.0.0-beta.7` release of `service-model-swift-code-generate`.  The error is caused by the Client Generator still using the old client name instead of the new one prefixed by `Generic`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
