### PR TITLE
Add client initializers that accept an HTTPClientInvocationAttributes instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,15 +202,17 @@ let operationsClient = APIGatewayPersistenceExampleOperationsClient(credentialsP
 let client = APIGatewayPersistenceExampleClient(operationsClient: operationsClient,
                                                 logger: logger)
 // Use the client within the request
-// This client doesn't need to be explicitly shutdown as it doesn't own the underlying http client
+// This client doesn't need to be explicitly shutdown 
+// as it doesn't own the underlying http client
+// client.shutdown() would be a no-op
 
 // End of application
 try await operationsClient.shutdown()
 ```
 
-### Using Mock client implementations for testing
+### Reusing Mock client implementations for testing
 
-Finally you can use the Mock and Throwing Mock client implementations for unit testing. These implementations 
+You can use the Mock and Throwing Mock client implementations for unit testing. These implementations 
 conform to the generated client protocol. Using this protocol within application code will allow you to test
 using a mock client and use the API Gateway client for actual usage.
 

--- a/README.md
+++ b/README.md
@@ -163,6 +163,7 @@ let model2Location = model1.asModel2Location()
 
 You can now use the client package from other Swift packages by depending on the Client target.
 
+### Basic Usage
 
 The easiest way to use the client is to initialize it directly and then at some later point shut it down.
 
@@ -186,6 +187,8 @@ assuming short-lived rotating AWS IAM credentials.
 The client initializer can also optionally accept `logger`, `timeoutConfiguration`, `connectionPoolConfiguration`,
 `retryConfiguration`, `eventLoopProvider` and `reportingConfiguration`.
 
+### Using Configuration or the underlying HTTP client
+
 For use cases where you want to reuse the underlying HTTP client between instances, you can use the operations client type
 (or similarly the configuration object type to share client configuration but not the underlying HTTP client).
 
@@ -205,6 +208,8 @@ let client = APIGatewayPersistenceExampleClient(operationsClient: operationsClie
 try await operationsClient.shutdown()
 ```
 
+### Using Mock client implementations for testing
+
 Finally you can use the Mock and Throwing Mock client implementations for unit testing. These implementations 
 conform to the generated client protocol. Using this protocol within application code will allow you to test
 using a mock client and use the API Gateway client for actual usage.
@@ -222,6 +227,31 @@ func testCodeThatUsesGetCustomerDetails() {
 
     // run a test using the mock client
 ```
+
+### Convenience initializers for web and service frameworks
+
+Each client also provides a set of convenience initializers using the `HTTPClientInvocationAttributes` protocol to pass
+the `Logger`, `EventLoop`, `InternalRequestId` and a metrics aggregator associated with the current request/invocation.
+
+For example, when using the `smoke-framework`, you can directly pass the provided `SmokeServerInvocationReporting` instance
+into the initializer of the client.
+
+```
+    public func getInvocationContext(
+            invocationReporting: SmokeServerInvocationReporting<SmokeInvocationTraceContext>) -> TheServiceContext {
+        let theClient = APIGatewayAnotherServiceClient(operationsClient: self.theOperationsClient, invocationAttributes: invocationReporting)
+        
+        ...
+        
+        return TheServiceContext(...
+                                 theClient: theClient,
+                                 ...)
+    }
+```
+
+If you want the client to ignore the `EventLoop` provided by the `HTTPClientInvocationAttributes` instance, you can 
+set `ignoreInvocationEventLoop` on the configuration object or operations client to `true`. Otherwise, the client will
+attempt to execute the client http requests on the same event loop as the provided invocation.
 
 # Generate the SmokeAWS library
 

--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ assuming short-lived rotating AWS IAM credentials.
 The client initializer can also optionally accept `logger`, `timeoutConfiguration`, `connectionPoolConfiguration`,
 `retryConfiguration`, `eventLoopProvider` and `reportingConfiguration`.
 
-### Using Configuration or the underlying HTTP client
+### Reusing Configuration or the underlying HTTP client
 
 For use cases where you want to reuse the underlying HTTP client between instances, you can use the operations client type
 (or similarly the configuration object type to share client configuration but not the underlying HTTP client).
@@ -210,7 +210,7 @@ let client = APIGatewayPersistenceExampleClient(operationsClient: operationsClie
 try await operationsClient.shutdown()
 ```
 
-### Reusing Mock client implementations for testing
+### Using Mock client implementations for testing
 
 You can use the Mock and Throwing Mock client implementations for unit testing. These implementations 
 conform to the generated client protocol. Using this protocol within application code will allow you to test

--- a/Sources/APIGatewayClientModelGenerate/APIGatewayClientCodeGeneration+generateClientApplicationFiles.swift
+++ b/Sources/APIGatewayClientModelGenerate/APIGatewayClientCodeGeneration+generateClientApplicationFiles.swift
@@ -135,6 +135,7 @@ extension APIGatewayClientCodeGeneration {
         
         fileBuilder.appendLine("""
                     .package(url: "https://github.com/amzn/smoke-aws.git", from: "2.35.31"),
+                    .package(url: "https://github.com/amzn/smoke-http.git", from: "2.14.0"),
                     .package(url: "https://github.com/apple/swift-log", from: "1.0.0"),
                     .package(url: "https://github.com/amzn/smoke-aws-generate.git", from: "3.0.0-beta.5"),
                     ],
@@ -170,6 +171,7 @@ extension APIGatewayClientCodeGeneration {
         
         fileBuilder.appendLine("""
                         .product(name: "SmokeAWSHttp", package: "smoke-aws"),
+                        .product(name: "SmokeHTTPClient", package: "smoke-http"),
                         .product(name: "APIGatewayClientModelGenerate", package: "smoke-aws-generate")
                         ],
                         plugins: [

--- a/Sources/SmokeAWSModelGenerate/ModelClientDelegate+addAWSClientInitializer.swift
+++ b/Sources/SmokeAWSModelGenerate/ModelClientDelegate+addAWSClientInitializer.swift
@@ -225,13 +225,12 @@ extension ModelClientDelegate {
             public init<TraceContextType: InvocationTraceContext, InvocationAttributesType: HTTPClientInvocationAttributes>(
                 config: \(configurationObjectName)<StandardHTTPClientCoreInvocationReporting<TraceContextType>>,
                 invocationAttributes: InvocationAttributesType,
-                ignoreInvocationEventLoop: Bool = false,
                 httpClient: HTTPOperationsClient? = nil)
             where InvocationReportingType == StandardHTTPClientCoreInvocationReporting<TraceContextType> {
                 self.init(config: config,
                           logger: invocationAttributes.logger,
                           internalRequestId: invocationAttributes.internalRequestId,
-                          eventLoop: !ignoreInvocationEventLoop ? invocationAttributes.eventLoop : nil,
+                          eventLoop: !config.ignoreInvocationEventLoop ? invocationAttributes.eventLoop : nil,
                           httpClient: httpClient,
                           outwardsRequestAggregator: invocationAttributes.outwardsRequestAggregator)
             }
@@ -244,13 +243,12 @@ extension ModelClientDelegate {
             
             public init<TraceContextType: InvocationTraceContext, InvocationAttributesType: HTTPClientInvocationAttributes>(
                 operationsClient: \(operationsClientName)<StandardHTTPClientCoreInvocationReporting<TraceContextType>>,
-                invocationAttributes: InvocationAttributesType,
-                ignoreInvocationEventLoop: Bool = false)
+                invocationAttributes: InvocationAttributesType)
             where InvocationReportingType == StandardHTTPClientCoreInvocationReporting<TraceContextType> {
                 self.init(operationsClient: operationsClient,
                           logger: invocationAttributes.logger,
                           internalRequestId: invocationAttributes.internalRequestId,
-                          eventLoop: !ignoreInvocationEventLoop ? invocationAttributes.eventLoop : nil,
+                          eventLoop: !operationsClient.config.ignoreInvocationEventLoop ? invocationAttributes.eventLoop : nil,
                           outwardsRequestAggregator: invocationAttributes.outwardsRequestAggregator)
             }
             """)
@@ -623,6 +621,7 @@ extension ModelClientDelegate {
         if case .genericTraceContextType = initializerType {
             fileBuilder.appendLine("""
                 self.reportingConfiguration = reportingConfiguration
+                self.ignoreInvocationEventLoop = ignoreInvocationEventLoop
                                 
                 self.reportingProvider = { (logger, internalRequestId, eventLoop) in
                     return StandardHTTPClientCoreInvocationReporting(
@@ -794,6 +793,7 @@ extension ModelClientDelegate {
                 public let retryConfiguration: HTTPClientRetryConfiguration
                 public let traceContext: InvocationReportingType.TraceContextType
                 public let reportingConfiguration: SmokeAWSClientReportingConfiguration<\(baseName)ModelOperations>
+                public let ignoreInvocationEventLoop: Bool
                 """)
         case .clientGenerator:
             fileBuilder.appendLine("""
@@ -890,6 +890,7 @@ extension ModelClientDelegate {
                 public let retryConfiguration: HTTPClientRetryConfiguration
                 public let traceContext: InvocationReportingType.TraceContextType
                 public let reportingConfiguration: SmokeAWSClientReportingConfiguration<\(baseName)ModelOperations>
+                public let ignoreInvocationEventLoop: Bool
                 """)
         case .clientGenerator:
             fileBuilder.appendLine("""
@@ -1077,6 +1078,12 @@ extension ModelClientDelegate {
                                     timeoutConfiguration: HTTPClient.Configuration.Timeout = .init(),
                         """)
                 }
+            }
+            
+            if case .configurationObject = entityType {
+                fileBuilder.appendLine("""
+                                ignoreInvocationEventLoop: Bool = false,
+                    """)
             }
             
             fileBuilder.appendLine("""

--- a/Sources/SmokeAWSModelGenerate/ModelClientDelegate+addAWSClientInitializer.swift
+++ b/Sources/SmokeAWSModelGenerate/ModelClientDelegate+addAWSClientInitializer.swift
@@ -381,6 +381,7 @@ extension ModelClientDelegate {
                 service: service,
                 contentType: contentType,
                 target: target,
+                ignoreInvocationEventLoop: ignoreInvocationEventLoop,
                 traceContext: \(traceContextValue),
                 timeoutConfiguration: timeoutConfiguration,
                 connectionPoolConfiguration: connectionPoolConfiguration,
@@ -1058,6 +1059,16 @@ extension ModelClientDelegate {
                             \(targetOrVersionParameter),
                 """)
             
+            switch entityType {
+            case .clientImplementation, .clientGenerator:
+                // nothing to do
+                break
+            case .configurationObject, .operationsClient:
+                fileBuilder.appendLine("""
+                        ignoreInvocationEventLoop: Bool = false,
+                """)
+            }
+            
             if !entityType.isClientImplementation && !entityType.isGenerator {
                 if case .genericTraceContextType = initializerType {
                     fileBuilder.appendLine("""
@@ -1078,12 +1089,6 @@ extension ModelClientDelegate {
                                     timeoutConfiguration: HTTPClient.Configuration.Timeout = .init(),
                         """)
                 }
-            }
-            
-            if case .configurationObject = entityType {
-                fileBuilder.appendLine("""
-                                ignoreInvocationEventLoop: Bool = false,
-                    """)
             }
             
             fileBuilder.appendLine("""


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Streamline initialising clients from a web or service framework using the `HTTPClientInvocationAttributes`. Added an example of using these initializers to the README.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
