### PR TITLE
Enable retry on ThrottlingException for StepFunctions and DynamoDB clients

### DIFF
--- a/Sources/SmokeAWSGenerate/DynamoDBConfiguration.swift
+++ b/Sources/SmokeAWSGenerate/DynamoDBConfiguration.swift
@@ -19,15 +19,18 @@ import Foundation
 import ServiceModelEntities
 
 internal struct DynamoDBConfiguration {
-    static let modelOverride = ModelOverride(matchCase: ["AttributeValue"],
-                                             fieldRawTypeOverride: ["Long": CommonConfiguration.intOverride])
+    static let modelOverride = ModelOverride(
+        matchCase: ["AttributeValue"],
+        fieldRawTypeOverride: ["Long": CommonConfiguration.intOverride],
+        additionalErrors: ["ThrottlingException"])
     
     static let httpClientConfiguration = HttpClientConfiguration(
         retryOnUnknownError: true,
         knownErrorsDefaultRetryBehavior: .fail,
         unretriableUnknownErrors: [],
         retriableUnknownErrors: ["ItemCollectionSizeLimitExceededException", "LimitExceededException",
-                                 "ProvisionedThroughputExceededException", "RequestLimitExceeded", "InternalServerError"])
+                                 "ProvisionedThroughputExceededException", "RequestLimitExceeded", "InternalServerError",
+                                 "ThrottlingException"])
     
     static let serviceModelDetails = ServiceModelDetails(
         serviceName: "dynamodb", serviceVersion: "2012-08-10",

--- a/Sources/SmokeAWSGenerate/StepFunctionsConfiguration.swift
+++ b/Sources/SmokeAWSGenerate/StepFunctionsConfiguration.swift
@@ -24,14 +24,16 @@ internal struct StepFunctionsConfiguration {
             ["DecisionType", "EventType", "HistoryEventType"]),
         fieldRawTypeOverride:
             [Fields.timestamp.typeDescription: CommonConfiguration.integerDateOverride,
-             "Long": CommonConfiguration.intOverride])
-    
+             "Long": CommonConfiguration.intOverride],
+        additionalErrors: ["ThrottlingException"])
+
     static let httpClientConfiguration = HttpClientConfiguration(
         retryOnUnknownError: true,
         knownErrorsDefaultRetryBehavior: .fail,
         unretriableUnknownErrors: [],
         retriableUnknownErrors: ["ActivityLimitExceeded", "ActivityWorkerLimitExceeded",
-                                 "ExecutionLimitExceeded", "StateMachineLimitExceeded"])
+                                 "ExecutionLimitExceeded", "StateMachineLimitExceeded",
+                                 "ThrottlingException"])
     
     static let serviceModelDetails = ServiceModelDetails(
         serviceName: "states", serviceVersion: "2016-11-23",

--- a/Sources/SmokeAWSModelGenerate/ModelClientDelegate+addAWSClientFileHeader.swift
+++ b/Sources/SmokeAWSModelGenerate/ModelClientDelegate+addAWSClientFileHeader.swift
@@ -106,7 +106,14 @@ extension ModelClientDelegate {
     }
     
     public func getSpecificErrors(codeGenerator: ServiceModelCodeGenerator, baseName: String) -> SpecificErrorBehaviour {
-        let sortedErrors = codeGenerator.getSortedErrors(allErrorTypes: codeGenerator.model.errorTypes)
+        let allErrorTypes: Set<String>
+        if let additionalErrors = codeGenerator.modelOverride?.additionalErrors {
+            allErrorTypes = codeGenerator.model.errorTypes.union(additionalErrors)
+        } else {
+            allErrorTypes = codeGenerator.model.errorTypes
+        }
+
+        let sortedErrors = codeGenerator.getSortedErrors(allErrorTypes: allErrorTypes)
         
         var retriableErrors: [String] = []
         var unretriableErrors: [String] = []

--- a/Sources/SmokeAWSModelGenerate/ServiceModelCodeGenerator+generateProtocolAsyncExtensions.swift
+++ b/Sources/SmokeAWSModelGenerate/ServiceModelCodeGenerator+generateProtocolAsyncExtensions.swift
@@ -132,7 +132,6 @@ public extension ServiceModelCodeGenerator {
                                   operationDescription: OperationDescription,
                                   operationSignature: OperationSignature) {
         let functionName = name.upperToLowerCamelCase
-        let baseName = applicationDescription.baseName
         fileBuilder.appendLine(" */")
         
         let input = operationSignature.input


### PR DESCRIPTION
*Issue #, if available:*

StepFunction client does not recognize and does not retry on throttling exception.

*Description of changes:*

1. Config changes in StepFunctions and DynamoDB client add a new error (that's not in the model) and make it retriable. The reason I also added DynamoDB in there is because DynamoDB service returns throttling exception on data operations if table is provisioned on-demand.
1. `Sources/SmokeAWSModelGenerate/ModelClientDelegate+addAWSClientFileHeader.swift` changes combines custom errors from the config with error from the model before creating retriable errors. This is what makes throttling error retriable in the client.
1. `Sources/SmokeAWSModelGenerate/ServiceModelCodeGenerator+generateProtocolAsyncExtensions.swift` removed line to fix lint error. The variable was unused.

*Testing*

Tested to make sure the fix works.

```
2022-09-17T17:02:27-0400 trace : outgoingRequestId=574DF8A8-8752-4437-824B-B9B022B810F3 [SmokeHTTPClient] Sending POST request to endpoint: https://states.us-west-2.amazonaws.com:443/ at path: /.
2022-09-17T17:02:27-0400 trace : bodyData={
  "includeExecutionData" : false,
  "executionArn" : "arn:aws:states:us-west-2:XXXX:execution:XXXX"
} bodyDataSize=201 method=POST outgoingRequestId=574DF8A8-8752-4437-824B-B9B022B810F3 uri=https://states.us-west-2.amazonaws.com:443/ [SmokeAWSHttp] Starting outgoing request.
2022-09-17T17:02:35-0400 trace : body={"__type":"com.amazon.coral.availability#ThrottlingException","message":"Rate exceeded"} outgoingRequestId=574DF8A8-8752-4437-824B-B9B022B810F3 [SmokeAWSHttp] Attempting to decode error data from JSON to StepFunctionsError
2022-09-17T17:02:35-0400 trace : bodyData={"__type":"com.amazon.coral.availability#ThrottlingException","message":"Rate exceeded"} bodyDataSize=88 code=400 error=HTTPClientError(responseCode: 400, cause: StepFunctionsModel.StepFunctionsError.throttling(StepFunctionsModel.StepFunctionsErrorPayload(type: "com.amazon.coral.availability#ThrottlingException", message: "Rate exceeded"))) outgoingRequestId=574DF8A8-8752-4437-824B-B9B022B810F3 x-amz-request-id=a07b8450-22b7-4705-b0c7-02b535e0a9d6 [SmokeAWSHttp] Unsuccessfully completed outgoing request.
2022-09-17T17:02:35-0400 warning : outgoingRequestId=574DF8A8-8752-4437-824B-B9B022B810F3 [SmokeHTTPClient] Request failed with error: HTTPClientError(responseCode: 400, cause: StepFunctionsModel.StepFunctionsError.throttling(StepFunctionsModel.StepFunctionsErrorPayload(type: "com.amazon.coral.availability#ThrottlingException", message: "Rate exceeded"))). Remaining retries: 5. Retrying in 220 ms.
2022-09-17T17:02:35-0400 trace : outgoingRequestId=574DF8A8-8752-4437-824B-B9B022B810F3 [SmokeHTTPClient] Reattempting request due to remaining retries: 5
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
