### PR TITLE
Update aws-sdk-go model tag to v1.44.60

### DIFF
--- a/Sources/SmokeAWSGenerate/main.swift
+++ b/Sources/SmokeAWSGenerate/main.swift
@@ -36,7 +36,7 @@ struct CommonConfiguration {
 }
 
 var isUsage = CommandLine.arguments.count == 2 && CommandLine.arguments[1] == "--help"
-let goRepositoryTag = "v1.44.46"
+let goRepositoryTag = "v1.44.60"
 
 let fileHeader = """
     // Copyright 2018-2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
@@ -290,10 +290,17 @@ private func generateSmokeAWS(tempDirURL: URL,
     if FileManager.default.fileExists(atPath: modelBaseFilePath, isDirectory: &isDirectory) {
         try FileManager.default.removeItem(at: modelBase)
     }
-    
-    _ = call(arguments: ["git", "clone", "--branch", goRepositoryTag, "https://github.com/aws/\(repositoryName).git", modelBaseFilePath])
-    
+
+    print("Cloning \(repositoryName) model @ \(goRepositoryTag)")
+
+    _ = call(arguments: ["git", "clone", "--branch", goRepositoryTag, "--filter=tree:0", "https://github.com/aws/\(repositoryName).git",
+                         modelBaseFilePath])
+
+    print ("Cloned \(repositoryName) model to \(modelBaseFilePath)")
+
     try serviceModelDetails.forEach { (details) in
+        print ("Generating model for \(details.baseName)")
+
         let applicationDescription = "The \(details.baseName)Service."
         
         let unrecognizedErrorDeclaration =

--- a/Sources/SmokeAWSGenerate/main.swift
+++ b/Sources/SmokeAWSGenerate/main.swift
@@ -296,10 +296,10 @@ private func generateSmokeAWS(tempDirURL: URL,
     _ = call(arguments: ["git", "clone", "--branch", goRepositoryTag, "--filter=tree:0", "https://github.com/aws/\(repositoryName).git",
                          modelBaseFilePath])
 
-    print ("Cloned \(repositoryName) model to \(modelBaseFilePath)")
+    print("Cloned \(repositoryName) model to \(modelBaseFilePath)")
 
     try serviceModelDetails.forEach { (details) in
-        print ("Generating model for \(details.baseName)")
+        print("Generating model for \(details.baseName)")
 
         let applicationDescription = "The \(details.baseName)Service."
         


### PR DESCRIPTION

*Issue #, if available:*

The last model `smoke-aws` was generated with is v1.44.60. This update sync `smoke-aws-generate` with that.
It also prints fetched model version to the terminal.

*Description of changes:*

Update aws-sdk-go model tag to v1.44.60 to sync up with `smoke-aws`.

Use treeless clone to speed up aws-sdk-go model cloning.

https://github.blog/2020-12-21-get-up-to-speed-with-partial-clone-and-shallow-clone/

> We strongly recommend that developers do not use treeless clones for their daily work. Treeless clones are really only helpful for automated builds when you want to quickly clone, compile a project, then throw away the repository. In environments like GitHub Actions using public runners, you want to minimize your clone time so you can spend your machine time actually building your software! Treeless clones might be an excellent option for those environments.

Performance testing: https://github.blog/2020-12-22-git-clone-a-data-driven-study-on-cloning-behaviors/

I tested this locally. Mostly just the download size. Perceived time to clone was similar to the study: full clone >>> shallow clone >= treeless clone in terms of time taken.

#### Normal Clone

```
clone --branch v1.44.60 https://github.com/aws/aws-sdk-go.git model-regular-clone
Cloning into 'model-regular-clone'...
remote: Enumerating objects: 105277, done.
remote: Counting objects: 100% (402/402), done.
remote: Compressing objects: 100% (190/190), done.
remote: Total 105277 (delta 171), reused 358 (delta 160), pack-reused 104875
Receiving objects: 100% (105277/105277), 256.40 MiB | 476.00 KiB/s, done.
Resolving deltas: 100% (67054/67054), done.
Note: switching to '694be8764ee72b4792a50b3659b039a1914a2b38'.
```

**256 MiB**

#### Treeless Clone

```
git clone --branch v1.44.60 --filter=tree:0 https://github.com/aws/aws-sdk-go.git model-treeless

remote: Enumerating objects: 5193, done.
remote: Counting objects: 100% (11/11), done.
remote: Compressing objects: 100% (11/11), done.
remote: Total 5193 (delta 0), reused 7 (delta 0), pack-reused 5182
Receiving objects: 100% (5193/5193), 1.94 MiB | 551.00 KiB/s, done.
Resolving deltas: 100% (283/283), done.
Note: switching to '694be8764ee72b4792a50b3659b039a1914a2b38'.

remote: Enumerating objects: 1433, done.
remote: Counting objects: 100% (341/341), done.
remote: Compressing objects: 100% (341/341), done.
remote: Total 1433 (delta 0), reused 0 (delta 0), pack-reused 1092
Receiving objects: 100% (1433/1433), 192.88 KiB | 415.00 KiB/s, done.
remote: Enumerating objects: 3722, done.
remote: Counting objects: 100% (2921/2921), done.
remote: Compressing objects: 100% (2255/2255), done.
remote: Total 3722 (delta 1730), reused 666 (delta 666), pack-reused 801
Receiving objects: 100% (3722/3722), 23.28 MiB | 489.00 KiB/s, done.
Resolving deltas: 100% (1888/1888), done.
Updating files: 100% (4033/4033), done.
```

**1.94 MiB + 192.88 KiB + 23.28 MiB**

#### Shallow Clone

```
git clone --branch v1.44.60 --depth=1 https://github.com/aws/aws-sdk-go.git model-depth

remote: Enumerating objects: 5156, done.
remote: Counting objects: 100% (5156/5156), done.
remote: Compressing objects: 100% (3618/3618), done.
remote: Total 5156 (delta 1904), reused 2568 (delta 837), pack-reused 0
Receiving objects: 100% (5156/5156), 23.40 MiB | 493.00 KiB/s, done.
Resolving deltas: 100% (1904/1904), done.
Note: switching to '694be8764ee72b4792a50b3659b039a1914a2b38'.
```

**23.40 MiB**

#### Comparison

Fetched code is the same. The only difference is inside `.git` folder.

```
diff -r -x .git model-regular-clone model-treeless
```

Running code generator also produces the same `smoke-aws` code.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
