### PR TITLE
Use shallow clone instead of treeless

### DIFF
--- a/Sources/SmokeAWSGenerate/main.swift
+++ b/Sources/SmokeAWSGenerate/main.swift
@@ -293,7 +293,7 @@ private func generateSmokeAWS(tempDirURL: URL,
 
     print("Cloning \(repositoryName) model @ \(goRepositoryTag)")
 
-    _ = call(arguments: ["git", "clone", "--branch", goRepositoryTag, "--filter=tree:0", "https://github.com/aws/\(repositoryName).git",
+    _ = call(arguments: ["git", "clone", "--branch", goRepositoryTag, "--depth=1", "https://github.com/aws/\(repositoryName).git",
                          modelBaseFilePath])
 
     print("Cloned \(repositoryName) model to \(modelBaseFilePath)")


### PR DESCRIPTION


*Issue #, if available:*

Use shallow clone instead of treeless. Shallow clone is faster. In my previous PR #71 I confused blobless clone with shallow clone. 

*Description of changes:*

Shallow clone is the fastest.

https://github.blog/2020-12-22-git-clone-a-data-driven-study-on-cloning-behaviors/

> Unsurprisingly, shallow clone is the fastest clone for the client, followed by a treeless then blobless partial clones, and finally full clones.

Local testing.

Treeless:
```
time git clone --branch v1.44.60 --filter=tree:0 https://github.com/aws/aws-sdk-go.git model-treeless
3.69s user 2.77s system 8% cpu 1:20.44 total
```

Shallow:
```
time git clone --branch v1.44.60 --depth=1 https://github.com/aws/aws-sdk-go.git model-depth
2.53s user 2.12s system 7% cpu 1:01.12 total
```


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
