### PR TITLE
Add dependency on openapi-swift-code-generate and bump service-model-swift-code-generate version

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,59 +1,61 @@
 {
-  "pins" : [
-    {
-      "identity" : "openapi-swift-code-generate",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/amzn/openapi-swift-code-generate.git",
-      "state" : {
-        "revision" : "f724141e19f151197b283ffe05acd7fc691f66d0",
-        "version" : "1.0.0-beta.1"
+  "object": {
+    "pins": [
+      {
+        "package": "OpenAPISwiftCodeGenerate",
+        "repositoryURL": "https://github.com/amzn/openapi-swift-code-generate.git",
+        "state": {
+          "branch": null,
+          "revision": "f724141e19f151197b283ffe05acd7fc691f66d0",
+          "version": "1.0.0-beta.1"
+        }
+      },
+      {
+        "package": "OpenAPIKit",
+        "repositoryURL": "https://github.com/mattpolzin/OpenAPIKit.git",
+        "state": {
+          "branch": null,
+          "revision": "0c668112f9803c1858ed070f9e8ce84922a0b41f",
+          "version": "3.0.0-alpha.4"
+        }
+      },
+      {
+        "package": "ServiceModelSwiftCodeGenerate",
+        "repositoryURL": "https://github.com/amzn/service-model-swift-code-generate.git",
+        "state": {
+          "branch": null,
+          "revision": "19a9564478f4f929683a36c66aa92d858dc66c8d",
+          "version": "3.0.0-beta.14"
+        }
+      },
+      {
+        "package": "SwaggerParser",
+        "repositoryURL": "https://github.com/tachyonics/SwaggerParser.git",
+        "state": {
+          "branch": null,
+          "revision": "c0eb70485c59a9d7dd6765dcd303b49fdb3040ee",
+          "version": "0.6.4"
+        }
+      },
+      {
+        "package": "swift-argument-parser",
+        "repositoryURL": "https://github.com/apple/swift-argument-parser",
+        "state": {
+          "branch": null,
+          "revision": "6b2aa2748a7881eebb9f84fb10c01293e15b52ca",
+          "version": "0.5.0"
+        }
+      },
+      {
+        "package": "Yams",
+        "repositoryURL": "https://github.com/jpsim/Yams.git",
+        "state": {
+          "branch": null,
+          "revision": "9ff1cc9327586db4e0c8f46f064b6a82ec1566fa",
+          "version": "4.0.6"
+        }
       }
-    },
-    {
-      "identity" : "openapikit",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/mattpolzin/OpenAPIKit.git",
-      "state" : {
-        "revision" : "0c668112f9803c1858ed070f9e8ce84922a0b41f",
-        "version" : "3.0.0-alpha.4"
-      }
-    },
-    {
-      "identity" : "service-model-swift-code-generate",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/amzn/service-model-swift-code-generate.git",
-      "state" : {
-        "revision" : "19a9564478f4f929683a36c66aa92d858dc66c8d",
-        "version" : "3.0.0-beta.14"
-      }
-    },
-    {
-      "identity" : "swaggerparser",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/tachyonics/SwaggerParser.git",
-      "state" : {
-        "revision" : "c0eb70485c59a9d7dd6765dcd303b49fdb3040ee",
-        "version" : "0.6.4"
-      }
-    },
-    {
-      "identity" : "swift-argument-parser",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-argument-parser",
-      "state" : {
-        "revision" : "6b2aa2748a7881eebb9f84fb10c01293e15b52ca",
-        "version" : "0.5.0"
-      }
-    },
-    {
-      "identity" : "yams",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/jpsim/Yams.git",
-      "state" : {
-        "revision" : "9ff1cc9327586db4e0c8f46f064b6a82ec1566fa",
-        "version" : "4.0.6"
-      }
-    }
-  ],
-  "version" : 2
+    ]
+  },
+  "version": 1
 }

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,52 +1,59 @@
 {
-  "object": {
-    "pins": [
-      {
-        "package": "OpenAPIKit",
-        "repositoryURL": "https://github.com/mattpolzin/OpenAPIKit.git",
-        "state": {
-          "branch": null,
-          "revision": "0c668112f9803c1858ed070f9e8ce84922a0b41f",
-          "version": "3.0.0-alpha.4"
-        }
-      },
-      {
-        "package": "ServiceModelSwiftCodeGenerate",
-        "repositoryURL": "https://github.com/amzn/service-model-swift-code-generate.git",
-        "state": {
-          "branch": null,
-          "revision": "a1adc01dc7c692d46484ccc2db154a1f62cb3d33",
-          "version": "3.0.0-beta.12"
-        }
-      },
-      {
-        "package": "SwaggerParser",
-        "repositoryURL": "https://github.com/tachyonics/SwaggerParser.git",
-        "state": {
-          "branch": null,
-          "revision": "c0eb70485c59a9d7dd6765dcd303b49fdb3040ee",
-          "version": "0.6.4"
-        }
-      },
-      {
-        "package": "swift-argument-parser",
-        "repositoryURL": "https://github.com/apple/swift-argument-parser",
-        "state": {
-          "branch": null,
-          "revision": "6b2aa2748a7881eebb9f84fb10c01293e15b52ca",
-          "version": "0.5.0"
-        }
-      },
-      {
-        "package": "Yams",
-        "repositoryURL": "https://github.com/jpsim/Yams.git",
-        "state": {
-          "branch": null,
-          "revision": "9ff1cc9327586db4e0c8f46f064b6a82ec1566fa",
-          "version": "4.0.6"
-        }
+  "pins" : [
+    {
+      "identity" : "openapi-swift-code-generate",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/amzn/openapi-swift-code-generate.git",
+      "state" : {
+        "revision" : "f724141e19f151197b283ffe05acd7fc691f66d0",
+        "version" : "1.0.0-beta.1"
       }
-    ]
-  },
-  "version": 1
+    },
+    {
+      "identity" : "openapikit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/mattpolzin/OpenAPIKit.git",
+      "state" : {
+        "revision" : "0c668112f9803c1858ed070f9e8ce84922a0b41f",
+        "version" : "3.0.0-alpha.4"
+      }
+    },
+    {
+      "identity" : "service-model-swift-code-generate",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/amzn/service-model-swift-code-generate.git",
+      "state" : {
+        "revision" : "19a9564478f4f929683a36c66aa92d858dc66c8d",
+        "version" : "3.0.0-beta.14"
+      }
+    },
+    {
+      "identity" : "swaggerparser",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/tachyonics/SwaggerParser.git",
+      "state" : {
+        "revision" : "c0eb70485c59a9d7dd6765dcd303b49fdb3040ee",
+        "version" : "0.6.4"
+      }
+    },
+    {
+      "identity" : "swift-argument-parser",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-argument-parser",
+      "state" : {
+        "revision" : "6b2aa2748a7881eebb9f84fb10c01293e15b52ca",
+        "version" : "0.5.0"
+      }
+    },
+    {
+      "identity" : "yams",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/jpsim/Yams.git",
+      "state" : {
+        "revision" : "9ff1cc9327586db4e0c8f46f064b6a82ec1566fa",
+        "version" : "4.0.6"
+      }
+    }
+  ],
+  "version" : 2
 }

--- a/Package.swift
+++ b/Package.swift
@@ -47,8 +47,9 @@ let package = Package(
             targets: ["APIGatewaySwiftGenerateClient"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/amzn/service-model-swift-code-generate.git", from: "3.0.0-beta.12"),
+        .package(url: "https://github.com/amzn/service-model-swift-code-generate.git", from: "3.0.0-beta.14"),
         .package(url: "https://github.com/apple/swift-argument-parser", from: "0.3.0"),
+        .package(url: "https://github.com/amzn/openapi-swift-code-generate.git", from: "1.0.0-beta.1"),
     ],
     targets: [
         .plugin(
@@ -71,14 +72,16 @@ let package = Package(
             name: "APIGatewayClientGenerate", dependencies: [
                 .target(name: "APIGatewayClientModelGenerate"),
                 .product(name: "ArgumentParser", package: "swift-argument-parser"),
-                .product(name: "OpenAPIServiceModel", package: "service-model-swift-code-generate"),
+                .product(name: "OpenAPIServiceModel", package: "openapi-swift-code-generate"),
+                .product(name: "SwaggerServiceModel", package: "openapi-swift-code-generate"),
             ]
         ),
         .executableTarget(
             name: "APIGatewayClientInitialize", dependencies: [
                 .target(name: "APIGatewayClientModelGenerate"),
                 .product(name: "ArgumentParser", package: "swift-argument-parser"),
-                .product(name: "OpenAPIServiceModel", package: "service-model-swift-code-generate"),
+                .product(name: "OpenAPIServiceModel", package: "openapi-swift-code-generate"),
+                .product(name: "SwaggerServiceModel", package: "openapi-swift-code-generate"),
             ]
         ),
         .target(

--- a/Package@swift-5.5.swift
+++ b/Package@swift-5.5.swift
@@ -44,6 +44,7 @@ let package = Package(
         .package(name: "ServiceModelSwiftCodeGenerate",
                  url: "https://github.com/amzn/service-model-swift-code-generate.git", from: "3.0.0-beta.12"),
         .package(url: "https://github.com/apple/swift-argument-parser", from: "0.3.0"),
+        .package(url: "https://github.com/amzn/openapi-swift-code-generate.git", from: "1.0.0-beta.1"),
     ],
     targets: [
         .executableTarget(
@@ -56,14 +57,16 @@ let package = Package(
             name: "APIGatewayClientGenerate", dependencies: [
                 .target(name: "APIGatewayClientModelGenerate"),
                 .product(name: "ArgumentParser", package: "swift-argument-parser"),
-                .product(name: "OpenAPIServiceModel", package: "ServiceModelSwiftCodeGenerate"),
+                .product(name: "OpenAPIServiceModel", package: "openapi-swift-code-generate"),
+                .product(name: "SwaggerServiceModel", package: "openapi-swift-code-generate"),
             ]
         ),
         .executableTarget(
             name: "APIGatewayClientInitialize", dependencies: [
                 .target(name: "APIGatewayClientModelGenerate"),
                 .product(name: "ArgumentParser", package: "swift-argument-parser"),
-                .product(name: "OpenAPIServiceModel", package: "ServiceModelSwiftCodeGenerate"),
+                .product(name: "OpenAPIServiceModel", package: "openapi-swift-code-generate"),
+                .product(name: "SwaggerServiceModel", package: "openapi-swift-code-generate"),
             ]
         ),
         .target(

--- a/Sources/APIGatewayClientInitialize/APIGatewayClientInitializeCommand.swift
+++ b/Sources/APIGatewayClientInitialize/APIGatewayClientInitializeCommand.swift
@@ -65,7 +65,7 @@ struct APIGatewayClientInitializeCommand: ParsableCommand {
     
     @Option(name: .customLong("version-requirement-type"),
             help: "For models hosted in an external product, the version requirement type of the package dependency.")
-    var versionRequirementType: VersionRequirementType?
+    var versionRequirementType: APIGatewayClientModelGenerate.VersionRequirementType?
     
     @Option(name: .customLong("model-target-name"), help: """
             When GenerationType == .codeGenModel, the name of this target;
@@ -85,7 +85,7 @@ struct APIGatewayClientInitializeCommand: ParsableCommand {
                                                                 applicationDescription: "The \(baseName) Swift client.",
                                                                 applicationSuffix: "")
         
-        let modelPackageDependency: ModelPackageDependency?
+        let modelPackageDependency: APIGatewayClientModelGenerate.ModelPackageDependency?
         if self.modelProductDependency != nil {
             guard let packageLocation = self.packageLocation, let versionRequirementType = self.versionRequirementType else {
                 fatalError("package-location and version-requirement-type must be specified if model-product-dependency is")
@@ -98,9 +98,9 @@ struct APIGatewayClientInitializeCommand: ParsableCommand {
             modelPackageDependency = nil
         }
         
-        let modelLocation = ModelLocation(modelFilePath: self.modelFilePath,
-                                          modelProductDependency: self.modelProductDependency,
-                                          modelTargetDependency: self.modelTargetDependency)
+        let modelLocation = APIGatewayClientModelGenerate.ModelLocation(modelFilePath: self.modelFilePath,
+                                                                        modelProductDependency: self.modelProductDependency,
+                                                                        modelTargetDependency: self.modelTargetDependency)
         
         let modelTargetName = self.modelTargetName ?? "\(baseName)Model"
         let clientTargetName = self.clientTargetName ?? "\(baseName)Client"

--- a/Sources/APIGatewayClientInitialize/APIGatewayClientSwiftCodeGen.swift
+++ b/Sources/APIGatewayClientInitialize/APIGatewayClientSwiftCodeGen.swift
@@ -9,9 +9,9 @@ import APIGatewayClientModelGenerate
 import ArgumentParser
 
 struct ModelLocations: Encodable {
-    let `default`: ModelLocation?
+    let `default`: APIGatewayClientModelGenerate.ModelLocation?
     
-    init(`default`: ModelLocation?) {
+    init(`default`: APIGatewayClientModelGenerate.ModelLocation?) {
         self.default = `default`
     }
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Adds dependency on openapi-swift-code-generate for OpenAPI and Swagger 
models
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
