### PR TITLE
Only depend on swift-argument-parser in the targets where it is required.

### DIFF
--- a/Sources/APIGatewayClientGenerate/APIGatewayClientGenerateCommand.swift
+++ b/Sources/APIGatewayClientGenerate/APIGatewayClientGenerateCommand.swift
@@ -18,6 +18,10 @@ enum APIGatewayClientGenerateCommandError: Error {
     case invalidParameterConbination(reason: String)
 }
 
+extension GenerationType: ExpressibleByArgument {
+    
+}
+
 @main
 struct APIGatewayClientGenerateCommand: ParsableCommand {
     static var configuration: CommandConfiguration {

--- a/Sources/APIGatewayClientModelGenerate/APIGatewayClientCodeGeneration.swift
+++ b/Sources/APIGatewayClientModelGenerate/APIGatewayClientCodeGeneration.swift
@@ -20,12 +20,11 @@ import ServiceModelCodeGeneration
 import ServiceModelEntities
 import ServiceModelGenerate
 import SmokeAWSModelGenerate
-import ArgumentParser
 
 /**
  The supported generation types.
  */
-public enum GenerationType: String, Codable, ExpressibleByArgument {
+public enum GenerationType: String, Codable {
     case codeGenModel
     case codeGenClient
 }


### PR DESCRIPTION

*Issue #, if available:*

*Description of changes:* Only depend on swift-argument-parser in the targets where it is required. Also fixes CI build failure.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
