### PR TITLE
Generate clients that depend on smoke-aws-support

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -23,9 +23,9 @@
         "package": "ServiceModelSwiftCodeGenerate",
         "repositoryURL": "https://github.com/amzn/service-model-swift-code-generate.git",
         "state": {
-          "branch": "no_smoke_aws",
-          "revision": "12c77bb92b77effc1cd9ed17cdb9db2c562b0d76",
-          "version": null
+          "branch": null,
+          "revision": "42c354dc16893d30d602bd24f8f570f20fc6206a",
+          "version": "3.0.0-rc.1"
         }
       },
       {

--- a/Package.resolved
+++ b/Package.resolved
@@ -15,17 +15,17 @@
         "repositoryURL": "https://github.com/mattpolzin/OpenAPIKit.git",
         "state": {
           "branch": null,
-          "revision": "0c668112f9803c1858ed070f9e8ce84922a0b41f",
-          "version": "3.0.0-alpha.4"
+          "revision": "15e39d1594b5da2b11d63f141203296d48cc5213",
+          "version": "3.0.0-alpha.5"
         }
       },
       {
         "package": "ServiceModelSwiftCodeGenerate",
         "repositoryURL": "https://github.com/amzn/service-model-swift-code-generate.git",
         "state": {
-          "branch": null,
-          "revision": "19a9564478f4f929683a36c66aa92d858dc66c8d",
-          "version": "3.0.0-beta.14"
+          "branch": "no_smoke_aws",
+          "revision": "12c77bb92b77effc1cd9ed17cdb9db2c562b0d76",
+          "version": null
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -47,7 +47,7 @@ let package = Package(
             targets: ["APIGatewaySwiftGenerateClient"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/amzn/service-model-swift-code-generate.git", from: "3.0.0-beta.14"),
+        .package(url: "https://github.com/amzn/service-model-swift-code-generate.git", branch: "no_smoke_aws"),
         .package(url: "https://github.com/apple/swift-argument-parser", from: "1.0.0"),
         .package(url: "https://github.com/amzn/openapi-swift-code-generate.git", from: "1.0.0-beta.1"),
     ],

--- a/Package.swift
+++ b/Package.swift
@@ -47,7 +47,7 @@ let package = Package(
             targets: ["APIGatewaySwiftGenerateClient"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/amzn/service-model-swift-code-generate.git", branch: "no_smoke_aws"),
+        .package(url: "https://github.com/amzn/service-model-swift-code-generate.git", from: "3.0.0-rc.1"),
         .package(url: "https://github.com/apple/swift-argument-parser", from: "1.0.0"),
         .package(url: "https://github.com/amzn/openapi-swift-code-generate.git", from: "1.0.0-beta.1"),
     ],

--- a/Package@swift-5.5.swift
+++ b/Package@swift-5.5.swift
@@ -42,7 +42,7 @@ let package = Package(
     ],
     dependencies: [
         .package(name: "ServiceModelSwiftCodeGenerate",
-                 url: "https://github.com/amzn/service-model-swift-code-generate.git", from: "3.0.0-beta.12"),
+                 url: "https://github.com/amzn/service-model-swift-code-generate.git", branch: "no_smoke_aws"),
         .package(url: "https://github.com/apple/swift-argument-parser", from: "1.0.0"),
         .package(url: "https://github.com/amzn/openapi-swift-code-generate.git", from: "1.0.0-beta.1"),
     ],

--- a/Package@swift-5.5.swift
+++ b/Package@swift-5.5.swift
@@ -42,7 +42,7 @@ let package = Package(
     ],
     dependencies: [
         .package(name: "ServiceModelSwiftCodeGenerate",
-                 url: "https://github.com/amzn/service-model-swift-code-generate.git", branch: "no_smoke_aws"),
+                 url: "https://github.com/amzn/service-model-swift-code-generate.git", from: "3.0.0-rc.1"),
         .package(url: "https://github.com/apple/swift-argument-parser", from: "1.0.0"),
         .package(url: "https://github.com/amzn/openapi-swift-code-generate.git", from: "1.0.0-beta.1"),
     ],

--- a/Sources/APIGatewayClientModelGenerate/APIGatewayClientCodeGeneration+generateClientApplicationFiles.swift
+++ b/Sources/APIGatewayClientModelGenerate/APIGatewayClientCodeGeneration+generateClientApplicationFiles.swift
@@ -104,7 +104,7 @@ extension APIGatewayClientCodeGenerator where TargetSupportType: ModelTargetSupp
                     .package(url: "https://github.com/amzn/smoke-aws-support.git", from: "1.0.0"),
                     .package(url: "https://github.com/amzn/smoke-http.git", from: "2.14.0"),
                     .package(url: "https://github.com/apple/swift-log", from: "1.0.0"),
-                    .package(url: "https://github.com/amzn/smoke-aws-generate.git", from: "3.0.0-beta.5"),
+                    .package(url: "https://github.com/amzn/smoke-aws-generate.git", from: "3.0.0-rc.1"),
                     ],
                 targets: [
                     // Targets are the basic building blocks of a package. A target can define a module or a test suite.

--- a/Sources/APIGatewayClientModelGenerate/APIGatewayClientCodeGeneration+generateClientApplicationFiles.swift
+++ b/Sources/APIGatewayClientModelGenerate/APIGatewayClientCodeGeneration+generateClientApplicationFiles.swift
@@ -101,7 +101,7 @@ extension APIGatewayClientCodeGenerator where TargetSupportType: ModelTargetSupp
         }
         
         fileBuilder.appendLine("""
-                    .package(url: "https://github.com/amzn/smoke-aws.git", from: "2.35.31"),
+                    .package(url: "https://github.com/amzn/smoke-aws-support.git", from: "1.0.0"),
                     .package(url: "https://github.com/amzn/smoke-http.git", from: "2.14.0"),
                     .package(url: "https://github.com/apple/swift-log", from: "1.0.0"),
                     .package(url: "https://github.com/amzn/smoke-aws-generate.git", from: "3.0.0-beta.5"),
@@ -137,7 +137,7 @@ extension APIGatewayClientCodeGenerator where TargetSupportType: ModelTargetSupp
         }
         
         fileBuilder.appendLine("""
-                        .product(name: "SmokeAWSHttp", package: "smoke-aws"),
+                        .product(name: "AWSHttp", package: "smoke-aws-support"),
                         .product(name: "SmokeHTTPClient", package: "smoke-http"),
                         .product(name: "APIGatewayClientModelGenerate", package: "smoke-aws-generate")
                         ],

--- a/Sources/APIGatewayClientModelGenerate/APIGatewayClientCodeGeneration.swift
+++ b/Sources/APIGatewayClientModelGenerate/APIGatewayClientCodeGeneration.swift
@@ -126,13 +126,13 @@ extension ServiceModelCodeGenerator where TargetSupportType: ModelTargetSupport 
                 asyncAwaitAPIs: asyncAwaitAPIs,
                 eventLoopFutureClientAPIs: eventLoopFutureClientAPIs,
                 minimumCompilerSupport: minimumCompilerSupport)
-            let mockClientDelegate = MockClientDelegate<TargetSupportType>(
+            let mockClientDelegate = MockAWSClientDelegate<TargetSupportType>(
                 baseName: applicationDescription.baseName,
                 isThrowingMock: false,
                 asyncAwaitAPIs: asyncAwaitAPIs,
                 eventLoopFutureClientAPIs: eventLoopFutureClientAPIs,
                 minimumCompilerSupport: minimumCompilerSupport)
-            let throwingClientDelegate = MockClientDelegate<TargetSupportType>(
+            let throwingClientDelegate = MockAWSClientDelegate<TargetSupportType>(
                 baseName: applicationDescription.baseName,
                 isThrowingMock: true,
                 asyncAwaitAPIs: asyncAwaitAPIs,
@@ -153,13 +153,13 @@ extension ServiceModelCodeGenerator where TargetSupportType: ModelTargetSupport 
                 generatorFileType = .clientGenerator
             }
             
-            generateClient(delegate: clientProtocolDelegate, fileType: .clientImplementation)
-            generateClient(delegate: mockClientDelegate, fileType: .clientImplementation)
-            generateClient(delegate: throwingClientDelegate, fileType: .clientImplementation)
-            generateClient(delegate: apiGatewayClientDelegate, fileType: .clientImplementation)
-            generateClient(delegate: apiGatewayClientDelegate, fileType: generatorFileType)
-            generateOperationsReporting()
-            generateInvocationsReporting()
+            generateAWSClient(delegate: clientProtocolDelegate, fileType: .clientImplementation)
+            generateAWSClient(delegate: mockClientDelegate, fileType: .clientImplementation)
+            generateAWSClient(delegate: throwingClientDelegate, fileType: .clientImplementation)
+            generateAWSClient(delegate: apiGatewayClientDelegate, fileType: .clientImplementation)
+            generateAWSClient(delegate: apiGatewayClientDelegate, fileType: generatorFileType)
+            generateAWSOperationsReporting()
+            generateAWSInvocationsReporting()
             generateModelOperationClientInput()
             generateModelOperationClientOutput()
         }

--- a/Sources/SmokeAWSModelGenerate/ModelClientDelegate+addAWSClientFileHeader.swift
+++ b/Sources/SmokeAWSModelGenerate/ModelClientDelegate+addAWSClientFileHeader.swift
@@ -26,9 +26,9 @@ extension ModelClientDelegate where TargetSupportType: ModelTargetSupport {
                                 fileBuilder: FileBuilder, baseName: String,
                                 fileType: ClientFileType, defaultInvocationTraceContext: InvocationTraceContextDeclaration) {
         fileBuilder.appendLine("""
-            import SmokeAWSHttp
+            import AWSCore
+            import AWSHttp
             import NIO
-            import NIOHTTP1
             import AsyncHTTPClient
             import Logging
             """)

--- a/Sources/SmokeAWSModelGenerate/ModelClientDelegate+addAWSClientInitializer.swift
+++ b/Sources/SmokeAWSModelGenerate/ModelClientDelegate+addAWSClientInitializer.swift
@@ -649,7 +649,7 @@ extension ModelClientDelegate {
                 public let target: String?
                 public let retryConfiguration: HTTPClientRetryConfiguration
                 public let traceContext: InvocationReportingType.TraceContextType
-                public let reportingConfiguration: SmokeAWSClientReportingConfiguration<\(baseName)ModelOperations>
+                public let reportingConfiguration: HTTPClientReportingConfiguration<\(baseName)ModelOperations>
                 public let ignoreInvocationEventLoop: Bool
                 """)
         case .clientGenerator:
@@ -746,7 +746,7 @@ extension ModelClientDelegate {
                 public let target: String?
                 public let retryConfiguration: HTTPClientRetryConfiguration
                 public let traceContext: InvocationReportingType.TraceContextType
-                public let reportingConfiguration: SmokeAWSClientReportingConfiguration<\(baseName)ModelOperations>
+                public let reportingConfiguration: HTTPClientReportingConfiguration<\(baseName)ModelOperations>
                 public let ignoreInvocationEventLoop: Bool
                 """)
         case .clientGenerator:
@@ -951,27 +951,27 @@ extension ModelClientDelegate {
                             connectionPoolConfiguration: HTTPClient.Configuration.ConnectionPool? = nil,
                             retryConfiguration: HTTPClientRetryConfiguration = .default,
                             eventLoopProvider: HTTPClient.EventLoopGroupProvider = .createNew,
-                            reportingConfiguration: SmokeAWSClientReportingConfiguration<\(baseName)ModelOperations>
+                            reportingConfiguration: HTTPClientReportingConfiguration<\(baseName)ModelOperations>
                 """)
             
             switch initializerType {
             case .standard, .forGenerator, .copyInitializer:
                 fileBuilder.appendLine("""
-                                    = SmokeAWSClientReportingConfiguration<\(baseName)ModelOperations>() ) {
+                                    = HTTPClientReportingConfiguration<\(baseName)ModelOperations>() ) {
                     """)
             case .genericTraceContextType, .traceContextTypeFromConfig:
                 fileBuilder.appendLine("""
-                                    = SmokeAWSClientReportingConfiguration<\(baseName)ModelOperations>() )
+                                    = HTTPClientReportingConfiguration<\(baseName)ModelOperations>() )
                     where InvocationReportingType == StandardHTTPClientCoreInvocationReporting<TraceContextType> {
                     """)
             case .usesDefaultReportingType(let defaultInvocationTraceContext):
                 fileBuilder.appendLine("""
-                                    = SmokeAWSClientReportingConfiguration<\(baseName)ModelOperations>() )
+                                    = HTTPClientReportingConfiguration<\(baseName)ModelOperations>() )
                     where InvocationReportingType == StandardHTTPClientCoreInvocationReporting<\(defaultInvocationTraceContext.name)> {
                     """)
             case .traceContextTypeFromOperationsClient:
                 fileBuilder.appendLine("""
-                                    = SmokeAWSClientReportingConfiguration<\(baseName)ModelOperations>() )
+                                    = HTTPClientReportingConfiguration<\(baseName)ModelOperations>() )
                     where InvocationReportingType == StandardHTTPClientCoreInvocationReporting<OperationsClientInvocationReportingType.TraceContextType> {
                     """)
             }

--- a/Sources/SmokeAWSModelGenerate/SmokeAWSModelGenerate.swift
+++ b/Sources/SmokeAWSModelGenerate/SmokeAWSModelGenerate.swift
@@ -100,7 +100,7 @@ public extension ServiceModelCodeGenerator where TargetSupportType: ModelTargetS
             targetImportName: "AWSCore") { (variableName, thePrefix, fileBuilder) in
                 fileBuilder.appendLine("""
                     \(thePrefix)StandardSmokeAWSOperationReporting(
-                    clientName: clientName, operation: .\(variableName), configuration: reportingConfiguration)
+                        clientName: clientName, operation: .\(variableName), configuration: reportingConfiguration)
                     """)
                 }
         


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Generate clients that depend on `smoke-aws-support` rather than on `smoke-aws`. Update code to reflect contract changes in `service-model-swift-code-generate` to avoid hard-coding smoke-aws[-support] references.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
