### PR TITLE
Use model type specific ModelOverride types.

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/amzn/openapi-swift-code-generate.git",
         "state": {
           "branch": null,
-          "revision": "f724141e19f151197b283ffe05acd7fc691f66d0",
-          "version": "1.0.0-beta.1"
+          "revision": "4210a8db0c2dc1e78bae9e302165c448d2ee361e",
+          "version": "1.0.0-rc.1"
         }
       },
       {
@@ -24,8 +24,8 @@
         "repositoryURL": "https://github.com/amzn/service-model-swift-code-generate.git",
         "state": {
           "branch": null,
-          "revision": "42c354dc16893d30d602bd24f8f570f20fc6206a",
-          "version": "3.0.0-rc.1"
+          "revision": "3cacd62f7290554185ffcf839ec75c4ee2584d8e",
+          "version": "3.0.0-rc.2"
         }
       },
       {
@@ -42,8 +42,8 @@
         "repositoryURL": "https://github.com/apple/swift-argument-parser",
         "state": {
           "branch": null,
-          "revision": "9f39744e025c7d377987f30b03770805dcb0bcd1",
-          "version": "1.1.4"
+          "revision": "fddd1c00396eed152c45a46bea9f47b98e59301d",
+          "version": "1.2.0"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -47,9 +47,9 @@ let package = Package(
             targets: ["APIGatewaySwiftGenerateClient"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/amzn/service-model-swift-code-generate.git", from: "3.0.0-rc.1"),
+        .package(url: "https://github.com/amzn/service-model-swift-code-generate.git", from: "3.0.0-rc.2"),
         .package(url: "https://github.com/apple/swift-argument-parser", from: "1.0.0"),
-        .package(url: "https://github.com/amzn/openapi-swift-code-generate.git", from: "1.0.0-beta.1"),
+        .package(url: "https://github.com/amzn/openapi-swift-code-generate.git", from: "1.0.0-rc.1"),
     ],
     targets: [
         .plugin(

--- a/Sources/APIGatewayClientGenerate/APIGatewayClientSwiftCodeGen.swift
+++ b/Sources/APIGatewayClientGenerate/APIGatewayClientSwiftCodeGen.swift
@@ -15,7 +15,7 @@ enum ModelFormat: String, Codable {
 struct APIGatewayClientSwiftCodeGen: Decodable {
     let modelFormat: ModelFormat?
     let baseName: String
-    let modelOverride: ModelOverride?
+    let modelOverride: ModelOverride<NoModelTypeOverrides>?
     let httpClientConfiguration: HttpClientConfiguration?
     let shapeProtocols: CodeGenFeatureStatus?
     let eventLoopFutureClientAPIs: CodeGenFeatureStatus?

--- a/Sources/APIGatewayClientModelGenerate/APIGatewayClientCodeGeneration.swift
+++ b/Sources/APIGatewayClientModelGenerate/APIGatewayClientCodeGeneration.swift
@@ -37,7 +37,7 @@ public struct APIGatewayClientCodeGeneration {
         modelTargetName: String, clientTargetName: String,
         customizations: CodeGenerationCustomizations,
         applicationDescription: ApplicationDescription,
-        modelOverride: ModelOverride?) throws
+        modelOverride: ModelOverride<ModelType.OverridesType>?) throws
     -> ModelType {
         let targetSupport = ModelAndClientTargetSupport(modelTargetName: modelTargetName,
                                                         clientTargetName: clientTargetName)
@@ -64,7 +64,7 @@ public struct APIGatewayClientCodeGeneration {
         modelTargetName: String, clientTargetName: String,
         customizations: CodeGenerationCustomizations,
         applicationDescription: ApplicationDescription,
-        modelOverride: ModelOverride?) throws {
+        modelOverride: ModelOverride<ModelType.OverridesType>?) throws {
             let targetSupport = ModelAndClientTargetSupport(modelTargetName: modelTargetName,
                                                             clientTargetName: clientTargetName)
             
@@ -90,7 +90,7 @@ public struct APIGatewayClientCodeGeneration {
         modelTargetName: String, clientTargetName: String,
         customizations: CodeGenerationCustomizations,
         applicationDescription: ApplicationDescription,
-        modelOverride: ModelOverride?) throws {
+        modelOverride: ModelOverride<ModelType.OverridesType>?) throws {
             let targetSupport = ModelAndClientTargetSupport(modelTargetName: modelTargetName,
                                                             clientTargetName: clientTargetName)
             
@@ -160,12 +160,12 @@ struct APIGatewayClientCodeGenerator<TargetSupportType> {
 
 extension ServiceModelCodeGenerator where TargetSupportType: ModelTargetSupport & ClientTargetSupport {
     
-    func generateFromModel<ModelType: ServiceModel>(serviceModel: ModelType,
-                                                    generationType: GenerationType,
-                                                    asyncAwaitAPIs: CodeGenFeatureStatus,
-                                                    eventLoopFutureClientAPIs: CodeGenFeatureStatus,
-                                                    minimumCompilerSupport: MinimumCompilerSupport,
-                                                    clientConfigurationType: ClientConfigurationType) throws {
+    func generateFromModel(serviceModel: ModelType,
+                           generationType: GenerationType,
+                           asyncAwaitAPIs: CodeGenFeatureStatus,
+                           eventLoopFutureClientAPIs: CodeGenFeatureStatus,
+                           minimumCompilerSupport: MinimumCompilerSupport,
+                           clientConfigurationType: ClientConfigurationType) throws {
         switch generationType {
         case .codeGenModel:
             let awsModelErrorsDelegate = APIGatewayClientModelErrorsDelegate()
@@ -176,24 +176,24 @@ extension ServiceModelCodeGenerator where TargetSupportType: ModelTargetSupport 
             generateModelErrors(delegate: awsModelErrorsDelegate)
             generateDefaultInstances(generationType: .internalTypes)
         case .codeGenClient:
-            let clientProtocolDelegate = ClientProtocolDelegate<TargetSupportType>(
+            let clientProtocolDelegate = ClientProtocolDelegate<ModelType, TargetSupportType>(
                 baseName: applicationDescription.baseName,
                 asyncAwaitAPIs: asyncAwaitAPIs,
                 eventLoopFutureClientAPIs: eventLoopFutureClientAPIs,
                 minimumCompilerSupport: minimumCompilerSupport)
-            let mockClientDelegate = MockAWSClientDelegate<TargetSupportType>(
+            let mockClientDelegate = MockAWSClientDelegate<ModelType, TargetSupportType>(
                 baseName: applicationDescription.baseName,
                 isThrowingMock: false,
                 asyncAwaitAPIs: asyncAwaitAPIs,
                 eventLoopFutureClientAPIs: eventLoopFutureClientAPIs,
                 minimumCompilerSupport: minimumCompilerSupport)
-            let throwingClientDelegate = MockAWSClientDelegate<TargetSupportType>(
+            let throwingClientDelegate = MockAWSClientDelegate<ModelType, TargetSupportType>(
                 baseName: applicationDescription.baseName,
                 isThrowingMock: true,
                 asyncAwaitAPIs: asyncAwaitAPIs,
                 eventLoopFutureClientAPIs: eventLoopFutureClientAPIs,
                 minimumCompilerSupport: minimumCompilerSupport)
-            let apiGatewayClientDelegate = APIGatewayClientDelegate<TargetSupportType>(
+            let apiGatewayClientDelegate = APIGatewayClientDelegate<ModelType, TargetSupportType>(
                 baseName: applicationDescription.baseName,
                 asyncAwaitAPIs: asyncAwaitAPIs,
                 eventLoopFutureClientAPIs: eventLoopFutureClientAPIs,

--- a/Sources/CoralToJSONServiceModel/CoralToJSONServiceModel.swift
+++ b/Sources/CoralToJSONServiceModel/CoralToJSONServiceModel.swift
@@ -295,7 +295,7 @@ public struct CoralToJSONServiceModel: Decodable {
 
 /// Use CoralToJSONModel as a ServiceModel
 extension CoralToJSONServiceModel: ServiceModel {
-    public static func create(data: Data, modelFormat: ModelFormat, modelOverride: ModelOverride?) throws -> CoralToJSONServiceModel {
+    public static func create(data: Data, modelFormat: ModelFormat, modelOverride: ModelOverride<OverridesType>?) throws -> CoralToJSONServiceModel {
         let decoder = JSONDecoder()
         
         return try decoder.decode(CoralToJSONServiceModel.self, from: data)

--- a/Sources/SmokeAWSGenerate/CloudFormationConfiguration.swift
+++ b/Sources/SmokeAWSGenerate/CloudFormationConfiguration.swift
@@ -38,7 +38,7 @@ private let additionalErrors: Set<String> = [
     "ValidationError"]
 
 internal struct CloudFormationConfiguration {
-    static let modelOverride = ModelOverride(enumerations:
+    static let modelOverride = ModelOverride<NoModelTypeOverrides>(enumerations:
         EnumerationNaming(usingUpperCamelCase: ["ChangeSource", "ChangeAction", "ChangeType", "EvaluationType",
                                                 "HandlerErrorCode", "Replacement", "RequiresRecreation", "ResourceAttribute"]),
                                              additionalErrors: additionalErrors)

--- a/Sources/SmokeAWSGenerate/CloudwatchConfiguration.swift
+++ b/Sources/SmokeAWSGenerate/CloudwatchConfiguration.swift
@@ -19,7 +19,7 @@ import Foundation
 import ServiceModelEntities
 
 internal struct CloudwatchConfiguration {
-    static let modelOverride = ModelOverride(fieldRawTypeOverride: ["Long": CommonConfiguration.intOverride])
+    static let modelOverride = ModelOverride<NoModelTypeOverrides>(fieldRawTypeOverride: ["Long": CommonConfiguration.intOverride])
     
     static let httpClientConfiguration = HttpClientConfiguration(
         retryOnUnknownError: true,

--- a/Sources/SmokeAWSGenerate/CodeBuildConfiguration.swift
+++ b/Sources/SmokeAWSGenerate/CodeBuildConfiguration.swift
@@ -19,7 +19,7 @@ import Foundation
 import ServiceModelEntities
 
 internal struct CodeBuildConfiguration {
-    static let modelOverride = ModelOverride(matchCase: [])
+    static let modelOverride = ModelOverride<NoModelTypeOverrides>(matchCase: [])
     
     static let httpClientConfiguration = HttpClientConfiguration(
         retryOnUnknownError: true,

--- a/Sources/SmokeAWSGenerate/CodePipelineConfiguration.swift
+++ b/Sources/SmokeAWSGenerate/CodePipelineConfiguration.swift
@@ -19,7 +19,7 @@ import Foundation
 import ServiceModelEntities
 
 internal struct CodePipelineConfiguration {
-    static let modelOverride = ModelOverride(
+    static let modelOverride = ModelOverride<NoModelTypeOverrides>(
         enumerations: EnumerationNaming(usingUpperCamelCase: ["ActionConfigurationPropertyType",
                                                               "ActionExecutionStatus",
                                                               "ActionOwner.ThirdParty",

--- a/Sources/SmokeAWSGenerate/DynamoDBConfiguration.swift
+++ b/Sources/SmokeAWSGenerate/DynamoDBConfiguration.swift
@@ -19,8 +19,8 @@ import Foundation
 import ServiceModelEntities
 
 internal struct DynamoDBConfiguration {
-    static let modelOverride = ModelOverride(matchCase: ["AttributeValue"],
-                                             fieldRawTypeOverride: ["Long": CommonConfiguration.intOverride])
+    static let modelOverride = ModelOverride<NoModelTypeOverrides>(matchCase: ["AttributeValue"],
+                                                                   fieldRawTypeOverride: ["Long": CommonConfiguration.intOverride])
     
     static let httpClientConfiguration = HttpClientConfiguration(
         retryOnUnknownError: true,

--- a/Sources/SmokeAWSGenerate/EC2Configuration.swift
+++ b/Sources/SmokeAWSGenerate/EC2Configuration.swift
@@ -371,7 +371,7 @@ private let additionalErrors: Set<String> = [
         "Unavailable"]
 
 internal struct EC2Configuration {
-    static let modelOverride = ModelOverride(
+    static let modelOverride = ModelOverride<NoModelTypeOverrides>(
         fieldRawTypeOverride: ["Long": CommonConfiguration.intOverride],
         additionalErrors: additionalErrors)
     

--- a/Sources/SmokeAWSGenerate/ECRConfiguration.swift
+++ b/Sources/SmokeAWSGenerate/ECRConfiguration.swift
@@ -20,7 +20,7 @@ import ServiceModelEntities
 
 internal struct ECRConfiguration {
     
-    static let modelOverride = ModelOverride(
+    static let modelOverride = ModelOverride<NoModelTypeOverrides>(
         enumerations: EnumerationNaming(usingUpperCamelCase: ["ImageFailureCode", "LayerFailureCode"]),
         fieldRawTypeOverride:
             [Fields.timestamp.typeDescription: CommonConfiguration.longDateOverride])

--- a/Sources/SmokeAWSGenerate/ECSConfiguration.swift
+++ b/Sources/SmokeAWSGenerate/ECSConfiguration.swift
@@ -19,7 +19,7 @@ import Foundation
 import ServiceModelEntities
 
 internal struct ECSConfiguration {
-    static let modelOverride = ModelOverride(fieldRawTypeOverride: ["Long": CommonConfiguration.intOverride])
+    static let modelOverride = ModelOverride<NoModelTypeOverrides>(fieldRawTypeOverride: ["Long": CommonConfiguration.intOverride])
 
     static let httpClientConfiguration = HttpClientConfiguration(
         retryOnUnknownError: true,

--- a/Sources/SmokeAWSGenerate/RDSConfiguration.swift
+++ b/Sources/SmokeAWSGenerate/RDSConfiguration.swift
@@ -19,8 +19,8 @@ import Foundation
 import ServiceModelEntities
 
 internal struct RDSConfiguration {
-    static let modelOverride = ModelOverride(matchCase: ["AttributeValue"],
-                                             fieldRawTypeOverride: ["Long": CommonConfiguration.intOverride])
+    static let modelOverride = ModelOverride<NoModelTypeOverrides>(matchCase: ["AttributeValue"],
+                                                                   fieldRawTypeOverride: ["Long": CommonConfiguration.intOverride])
     
     static let httpClientConfiguration = HttpClientConfiguration(
         retryOnUnknownError: true,

--- a/Sources/SmokeAWSGenerate/RDSDataConfiguration.swift
+++ b/Sources/SmokeAWSGenerate/RDSDataConfiguration.swift
@@ -19,7 +19,7 @@ import Foundation
 import ServiceModelEntities
 
 internal struct RDSDataConfiguration {
-    static let modelOverride = ModelOverride(fieldRawTypeOverride: ["Long": CommonConfiguration.intOverride])
+    static let modelOverride = ModelOverride<NoModelTypeOverrides>(fieldRawTypeOverride: ["Long": CommonConfiguration.intOverride])
 
     static let httpClientConfiguration = HttpClientConfiguration(
         retryOnUnknownError: true,

--- a/Sources/SmokeAWSGenerate/S3Configuration.swift
+++ b/Sources/SmokeAWSGenerate/S3Configuration.swift
@@ -30,7 +30,7 @@ internal struct S3Configuration {
         retriableUnknownErrors: [],
         additionalClients: ["dataHttpClient": additionalHttpClient])
     
-    static let modelOverride = ModelOverride(enumerations:
+    static let modelOverride = ModelOverride<NoModelTypeOverrides>(enumerations:
         EnumerationNaming(usingUpperCamelCase: ["Event"]),
                                              fieldRawTypeOverride: ["Long": CommonConfiguration.intOverride])
     

--- a/Sources/SmokeAWSGenerate/SNSConfiguration.swift
+++ b/Sources/SmokeAWSGenerate/SNSConfiguration.swift
@@ -19,7 +19,7 @@ import Foundation
 import ServiceModelEntities
 
 internal struct SNSConfiguration {
-    static let modelOverride = ModelOverride(
+    static let modelOverride = ModelOverride<NoModelTypeOverrides>(
         codingKeyOverrides: ["AuthorizationErrorException.message": "Message",
                              "EndpointDisabledException.message": "Message",
                              "FilterPolicyLimitExceededException.message": "Message",

--- a/Sources/SmokeAWSGenerate/SimpleQueueConfiguration.swift
+++ b/Sources/SmokeAWSGenerate/SimpleQueueConfiguration.swift
@@ -42,7 +42,7 @@ internal struct SimpleQueueConfiguration {
          "TagQueue": overrideInputDescription,
          "UntagQueue": overrideInputDescription]
     
-    static let modelOverride = ModelOverride(
+    static let modelOverride = ModelOverride<NoModelTypeOverrides>(
         operationInputOverrides: operationInputOverrides,
         codingKeyOverrides: ["ReceiveMessageResult.Messages": "Message",
                              "ChangeMessageVisibilityBatchRequest.Entries": "ChangeMessageVisibilityBatchRequestEntry",

--- a/Sources/SmokeAWSGenerate/SimpleWorkflowConfiguration.swift
+++ b/Sources/SmokeAWSGenerate/SimpleWorkflowConfiguration.swift
@@ -19,7 +19,7 @@ import Foundation
 import ServiceModelEntities
 
 internal struct SimpleWorkflowConfiguration {
-    static let modelOverride = ModelOverride(
+    static let modelOverride = ModelOverride<NoModelTypeOverrides>(
         fieldRawTypeOverride:
             [Fields.timestamp.typeDescription: CommonConfiguration.integerDateOverride,
              "Long": CommonConfiguration.intOverride])

--- a/Sources/SmokeAWSGenerate/StepFunctionsConfiguration.swift
+++ b/Sources/SmokeAWSGenerate/StepFunctionsConfiguration.swift
@@ -19,7 +19,7 @@ import Foundation
 import ServiceModelEntities
 
 internal struct StepFunctionsConfiguration {
-    static let modelOverride = ModelOverride(
+    static let modelOverride = ModelOverride<NoModelTypeOverrides>(
         enumerations: EnumerationNaming(usingUpperCamelCase:
             ["DecisionType", "EventType", "HistoryEventType"]),
         fieldRawTypeOverride:

--- a/Sources/SmokeAWSGenerate/main.swift
+++ b/Sources/SmokeAWSGenerate/main.swift
@@ -246,7 +246,7 @@ struct ServiceModelDetails {
     let serviceName: String
     let serviceVersion: String
     let baseName: String
-    let modelOverride: ModelOverride?
+    let modelOverride: ModelOverride<NoModelTypeOverrides>?
     let httpClientConfiguration: HttpClientConfiguration
     let signAllHeaders: Bool
 }

--- a/Sources/SmokeAWSModelGenerate/APIGatewayClientDelegate.swift
+++ b/Sources/SmokeAWSModelGenerate/APIGatewayClientDelegate.swift
@@ -23,7 +23,7 @@ import ServiceModelEntities
  A ModelClientDelegate that can be used to generate an
  API Gateway Client from a Service Model.
  */
-public struct APIGatewayClientDelegate<TargetSupportType>: ModelClientDelegate
+public struct APIGatewayClientDelegate<ModelType: ServiceModel, TargetSupportType>: ModelClientDelegate
 where TargetSupportType: ModelTargetSupport {
     public let clientType: ClientType
     public let baseName: String
@@ -74,7 +74,7 @@ where TargetSupportType: ModelTargetSupport {
         self.defaultInvocationTraceContext = defaultInvocationTraceContext
     }
     
-    public func addTypeDescription(codeGenerator: ServiceModelCodeGenerator<TargetSupportType>,
+    public func addTypeDescription(codeGenerator: ServiceModelCodeGenerator<ModelType, TargetSupportType>,
                                    delegate: Self,
                                    fileBuilder: FileBuilder,
                                    entityType: ClientEntityType) {
@@ -98,7 +98,7 @@ where TargetSupportType: ModelTargetSupport {
         }
     }
     
-    public func addCustomFileHeader(codeGenerator: ServiceModelCodeGenerator<TargetSupportType>,
+    public func addCustomFileHeader(codeGenerator: ServiceModelCodeGenerator<ModelType, TargetSupportType>,
                                     delegate: Self,
                                     fileBuilder: FileBuilder,
                                     fileType: ClientFileType) {
@@ -106,7 +106,7 @@ where TargetSupportType: ModelTargetSupport {
                                defaultInvocationTraceContext: self.defaultInvocationTraceContext)
     }
     
-    public func addCommonFunctions(codeGenerator: ServiceModelCodeGenerator<TargetSupportType>,
+    public func addCommonFunctions(codeGenerator: ServiceModelCodeGenerator<ModelType, TargetSupportType>,
                                    delegate: Self,
                                    fileBuilder: FileBuilder,
                                    sortedOperations: [(String, OperationDescription)],
@@ -129,7 +129,7 @@ where TargetSupportType: ModelTargetSupport {
                                     entityType: entityType)
     }
     
-    public func addOperationBody(codeGenerator: ServiceModelCodeGenerator<TargetSupportType>,
+    public func addOperationBody(codeGenerator: ServiceModelCodeGenerator<ModelType, TargetSupportType>,
                                  delegate: Self,
                                  fileBuilder: FileBuilder, invokeType: InvokeType,
                                  operationName: String,
@@ -157,7 +157,7 @@ where TargetSupportType: ModelTargetSupport {
     
     private func addAPIGatewayClientOperationBody(
             operationName: String,
-            codeGenerator: ServiceModelCodeGenerator<TargetSupportType>,
+            codeGenerator: ServiceModelCodeGenerator<ModelType, TargetSupportType>,
             fileBuilder: FileBuilder,
             function: APIGatewayClientFunction,
             httpVerb: String,

--- a/Sources/SmokeAWSModelGenerate/AWSClientDelegate+addAWSClientOperationBody.swift
+++ b/Sources/SmokeAWSModelGenerate/AWSClientDelegate+addAWSClientOperationBody.swift
@@ -23,7 +23,7 @@ internal extension AWSClientDelegate {
     func addAWSClientOperationBody(
             name: String,
             fileBuilder: FileBuilder,
-            codeGenerator: ServiceModelCodeGenerator<TargetSupportType>,
+            codeGenerator: ServiceModelCodeGenerator<ModelType, TargetSupportType>,
             function: AWSClientFunction,
             http: (verb: String, url: String), invokeType: InvokeType,
             signAllHeaders: Bool) {

--- a/Sources/SmokeAWSModelGenerate/AWSClientDelegate+addAWSClientQueryOperationBody.swift
+++ b/Sources/SmokeAWSModelGenerate/AWSClientDelegate+addAWSClientQueryOperationBody.swift
@@ -23,7 +23,7 @@ internal extension AWSClientDelegate {
     func addAWSClientQueryOperationBody(
             name: String,
             fileBuilder: FileBuilder,
-            codeGenerator: ServiceModelCodeGenerator<TargetSupportType>,
+            codeGenerator: ServiceModelCodeGenerator<ModelType, TargetSupportType>,
             function: AWSClientFunction,
             http: (verb: String, url: String),
             invokeType: InvokeType,

--- a/Sources/SmokeAWSModelGenerate/AWSClientDelegate.swift
+++ b/Sources/SmokeAWSModelGenerate/AWSClientDelegate.swift
@@ -23,7 +23,7 @@ import ServiceModelEntities
  A ModelClientDelegate that can be used to generate an
  AWS Client from a Service Model.
  */
-public struct AWSClientDelegate<TargetSupportType>: ModelClientDelegate
+public struct AWSClientDelegate<ModelType: ServiceModel, TargetSupportType>: ModelClientDelegate
 where TargetSupportType: ModelTargetSupport {
     public let clientType: ClientType
     public let clientAttributes: AWSClientAttributes
@@ -71,7 +71,7 @@ where TargetSupportType: ModelTargetSupport {
         self.signAllHeaders = signAllHeaders
     }
     
-    public func addTypeDescription(codeGenerator: ServiceModelCodeGenerator<TargetSupportType>,
+    public func addTypeDescription(codeGenerator: ServiceModelCodeGenerator<ModelType, TargetSupportType>,
                                    delegate: Self,
                                    fileBuilder: FileBuilder,
                                    entityType: ClientEntityType) {
@@ -86,7 +86,7 @@ where TargetSupportType: ModelTargetSupport {
         }
     }
     
-    public func addCustomFileHeader(codeGenerator: ServiceModelCodeGenerator<TargetSupportType>,
+    public func addCustomFileHeader(codeGenerator: ServiceModelCodeGenerator<ModelType, TargetSupportType>,
                                     delegate: Self,
                                     fileBuilder: FileBuilder,
                                     fileType: ClientFileType) {
@@ -94,7 +94,7 @@ where TargetSupportType: ModelTargetSupport {
                                defaultInvocationTraceContext: self.clientAttributes.defaultInvocationTraceContext)
     }
     
-    public func addCommonFunctions(codeGenerator: ServiceModelCodeGenerator<TargetSupportType>,
+    public func addCommonFunctions(codeGenerator: ServiceModelCodeGenerator<ModelType, TargetSupportType>,
                                    delegate: Self,
                                    fileBuilder: FileBuilder,
                                    sortedOperations: [(String, OperationDescription)],
@@ -109,7 +109,7 @@ where TargetSupportType: ModelTargetSupport {
                                     entityType: entityType)
     }
     
-    public func addOperationBody(codeGenerator: ServiceModelCodeGenerator<TargetSupportType>,
+    public func addOperationBody(codeGenerator: ServiceModelCodeGenerator<ModelType, TargetSupportType>,
                                  delegate: Self,
                                  fileBuilder: FileBuilder,
                                  invokeType: InvokeType,

--- a/Sources/SmokeAWSModelGenerate/ModelClientDelegate+addAWSClientDeinitializer.swift
+++ b/Sources/SmokeAWSModelGenerate/ModelClientDelegate+addAWSClientDeinitializer.swift
@@ -23,7 +23,7 @@ import CoralToJSONServiceModel
 extension ModelClientDelegate {
     func addAWSClientDeinitializer(fileBuilder: FileBuilder, baseName: String,
                                    clientAttributes: AWSClientAttributes,
-                                   codeGenerator: ServiceModelCodeGenerator<TargetSupportType>,
+                                   codeGenerator: ServiceModelCodeGenerator<ModelType, TargetSupportType>,
                                    targetsAPIGateway: Bool,
                                    contentType: String,
                                    entityType: ClientEntityType) {
@@ -77,7 +77,7 @@ extension ModelClientDelegate {
     private func addShutdownMethod(methodName: String,
                                    isAsync: Bool,
                                    fileBuilder: FileBuilder,
-                                   codeGenerator: ServiceModelCodeGenerator<TargetSupportType>,
+                                   codeGenerator: ServiceModelCodeGenerator<ModelType, TargetSupportType>,
                                    entityType: ClientEntityType) {
         let httpClientConfiguration = codeGenerator.customizations.httpClientConfiguration
         

--- a/Sources/SmokeAWSModelGenerate/ModelClientDelegate+addAWSClientFileHeader.swift
+++ b/Sources/SmokeAWSModelGenerate/ModelClientDelegate+addAWSClientFileHeader.swift
@@ -22,7 +22,7 @@ import ServiceModelGenerate
 import CoralToJSONServiceModel
 
 extension ModelClientDelegate where TargetSupportType: ModelTargetSupport {
-    func addAWSClientFileHeader(codeGenerator: ServiceModelCodeGenerator<TargetSupportType>,
+    func addAWSClientFileHeader(codeGenerator: ServiceModelCodeGenerator<ModelType, TargetSupportType>,
                                 fileBuilder: FileBuilder, baseName: String,
                                 fileType: ClientFileType, defaultInvocationTraceContext: InvocationTraceContextDeclaration) {
         fileBuilder.appendLine("""

--- a/Sources/SmokeAWSModelGenerate/ModelClientDelegate+addAWSClientInitializer.swift
+++ b/Sources/SmokeAWSModelGenerate/ModelClientDelegate+addAWSClientInitializer.swift
@@ -31,7 +31,7 @@ public enum DelegateStatementType {
 extension ModelClientDelegate {
     func addAWSClientInitializerAndMembers(fileBuilder: FileBuilder, baseName: String,
                                            clientAttributes: AWSClientAttributes,
-                                           codeGenerator: ServiceModelCodeGenerator<TargetSupportType>,
+                                           codeGenerator: ServiceModelCodeGenerator<ModelType, TargetSupportType>,
                                            targetsAPIGateway: Bool,
                                            contentType: String,
                                            sortedOperations: [(String, OperationDescription)],
@@ -178,7 +178,7 @@ extension ModelClientDelegate {
     
     private func addAWSClientInitializer(fileBuilder: FileBuilder, baseName: String,
                                          clientAttributes: AWSClientAttributes,
-                                         codeGenerator: ServiceModelCodeGenerator<TargetSupportType>,
+                                         codeGenerator: ServiceModelCodeGenerator<ModelType, TargetSupportType>,
                                          endpointDefault: String, regionDefault: String,
                                          regionAssignmentPostfix: String, targetsAPIGateway: Bool,
                                          contentType: String, contentTypeAssignment: String, targetAssignment: String,
@@ -255,7 +255,7 @@ extension ModelClientDelegate {
             contentType: String,
             httpClientConfiguration: HttpClientConfiguration,
             baseName: String,
-            codeGenerator: ServiceModelCodeGenerator<TargetSupportType>,
+            codeGenerator: ServiceModelCodeGenerator<ModelType, TargetSupportType>,
             regionAssignmentPostfix: String,
             targetAssignment: String,
             targetsAPIGateway: Bool,
@@ -502,7 +502,7 @@ extension ModelClientDelegate {
     
     private func addAdditionalHttpClients(
             httpClientConfiguration: HttpClientConfiguration,
-            codeGenerator: ServiceModelCodeGenerator<TargetSupportType>,
+            codeGenerator: ServiceModelCodeGenerator<ModelType, TargetSupportType>,
             fileBuilder: FileBuilder, initializerType: InitializerType,
             connectionTimeoutEqualityLine: String) {
         httpClientConfiguration.additionalClients?.forEach { (key, _) in
@@ -611,7 +611,7 @@ extension ModelClientDelegate {
             contentType: String,
             baseName: String,
             httpClientConfiguration: HttpClientConfiguration,
-            codeGenerator: ServiceModelCodeGenerator<TargetSupportType>,
+            codeGenerator: ServiceModelCodeGenerator<ModelType, TargetSupportType>,
             entityType: ClientEntityType) {
         if entityType.isClientImplementation || entityType.isGenerator {
             fileBuilder.appendLine("""
@@ -709,7 +709,7 @@ extension ModelClientDelegate {
             contentType: String,
             baseName: String,
             httpClientConfiguration: HttpClientConfiguration,
-            codeGenerator: ServiceModelCodeGenerator<TargetSupportType>,
+            codeGenerator: ServiceModelCodeGenerator<ModelType, TargetSupportType>,
             targetsAPIGateway: Bool,
             entityType: ClientEntityType) {
         if entityType.isClientImplementation || entityType.isGenerator {
@@ -811,7 +811,7 @@ extension ModelClientDelegate {
             fileBuilder: FileBuilder,
             baseName: String,
             httpClientConfiguration: HttpClientConfiguration,
-            codeGenerator: ServiceModelCodeGenerator<TargetSupportType>,
+            codeGenerator: ServiceModelCodeGenerator<ModelType, TargetSupportType>,
             regionDefault: String,
             endpointDefault: String,
             targetsAPIGateway: Bool,
@@ -992,7 +992,7 @@ extension ModelClientDelegate {
     public func addAWSClientGeneratorWithReporting(
             fileBuilder: FileBuilder,
             baseName: String,
-            codeGenerator: ServiceModelCodeGenerator<TargetSupportType>,
+            codeGenerator: ServiceModelCodeGenerator<ModelType, TargetSupportType>,
             targetsAPIGateway: Bool,
             clientAttributes: AWSClientAttributes,
             contentType: String) {
@@ -1006,7 +1006,7 @@ extension ModelClientDelegate {
     public func addAWSClientGeneratorWithReporting(
             fileBuilder: FileBuilder,
             baseName: String,
-            codeGenerator: ServiceModelCodeGenerator<TargetSupportType>,
+            codeGenerator: ServiceModelCodeGenerator<ModelType, TargetSupportType>,
             targetsAPIGateway: Bool,
             contentType: String) {
         guard case .struct(let clientName, _, _) = clientType else {
@@ -1066,7 +1066,7 @@ extension ModelClientDelegate {
     public func addAWSClientGeneratorWithAWSTraceContext(
             fileBuilder: FileBuilder,
             baseName: String,
-            codeGenerator: ServiceModelCodeGenerator<TargetSupportType>,
+            codeGenerator: ServiceModelCodeGenerator<ModelType, TargetSupportType>,
             targetsAPIGateway: Bool,
             clientAttributes: AWSClientAttributes,
             contentType: String) {
@@ -1081,7 +1081,7 @@ extension ModelClientDelegate {
     public func addAWSClientGeneratorWithLogger(
             fileBuilder: FileBuilder,
             baseName: String,
-            codeGenerator: ServiceModelCodeGenerator<TargetSupportType>,
+            codeGenerator: ServiceModelCodeGenerator<ModelType, TargetSupportType>,
             targetsAPIGateway: Bool,
             invocationTraceContext: InvocationTraceContextDeclaration,
             contentType: String) {

--- a/Sources/SmokeAWSModelGenerate/ModelClientDelegate+commonAWSFunctions.swift
+++ b/Sources/SmokeAWSModelGenerate/ModelClientDelegate+commonAWSFunctions.swift
@@ -24,7 +24,7 @@ import CoralToJSONServiceModel
 extension ModelClientDelegate {
     func addAWSClientCommonFunctions(fileBuilder: FileBuilder, baseName: String,
                                      clientAttributes: AWSClientAttributes,
-                                     codeGenerator: ServiceModelCodeGenerator<TargetSupportType>,
+                                     codeGenerator: ServiceModelCodeGenerator<ModelType, TargetSupportType>,
                                      targetsAPIGateway: Bool,
                                      contentType: String,
                                      sortedOperations: [(String, OperationDescription)],

--- a/Sources/SmokeAWSModelGenerate/SmokeAWSModelGenerate.swift
+++ b/Sources/SmokeAWSModelGenerate/SmokeAWSModelGenerate.swift
@@ -27,7 +27,7 @@ public struct SmokeAWSModelGenerate {
         modelFilePath: String,
         customizations: CodeGenerationCustomizations,
         applicationDescription: ApplicationDescription,
-        modelOverride: ModelOverride?,
+        modelOverride: ModelOverride<NoModelTypeOverrides>?,
         signAllHeaders: Bool) throws
     -> CoralToJSONServiceModel {
         return try ServiceModelGenerate.generateFromModel(
@@ -48,21 +48,22 @@ extension ServiceModelCodeGenerator where TargetSupportType: ModelTargetSupport 
     func generateFromCoralToJSONServiceModel(
             coralToJSONServiceModel: CoralToJSONServiceModel,
             asyncAwaitAPIs: CodeGenFeatureStatus,
-            signAllHeaders: Bool) throws {
+            signAllHeaders: Bool) throws
+    where ModelType == CoralToJSONServiceModel {
         let awsClientAttributes = coralToJSONServiceModel.getAWSClientAttributes()
         
-        let clientProtocolDelegate = ClientProtocolDelegate<TargetSupportType>(
+        let clientProtocolDelegate = ClientProtocolDelegate<CoralToJSONServiceModel, TargetSupportType>(
             baseName: applicationDescription.baseName,
             asyncAwaitAPIs: asyncAwaitAPIs)
-        let mockClientDelegate = MockAWSClientDelegate<TargetSupportType>(
+        let mockClientDelegate = MockAWSClientDelegate<CoralToJSONServiceModel, TargetSupportType>(
             baseName: applicationDescription.baseName,
             isThrowingMock: false,
             asyncAwaitAPIs: asyncAwaitAPIs)
-        let throwingClientDelegate = MockAWSClientDelegate<TargetSupportType>(
+        let throwingClientDelegate = MockAWSClientDelegate<CoralToJSONServiceModel, TargetSupportType>(
             baseName: applicationDescription.baseName,
             isThrowingMock: true,
             asyncAwaitAPIs: asyncAwaitAPIs)
-        let awsClientDelegate = AWSClientDelegate<TargetSupportType>(
+        let awsClientDelegate = AWSClientDelegate<CoralToJSONServiceModel, TargetSupportType>(
             baseName: applicationDescription.baseName,
             clientAttributes: awsClientAttributes,
             signAllHeaders: signAllHeaders,
@@ -88,7 +89,7 @@ extension ServiceModelCodeGenerator where TargetSupportType: ModelTargetSupport 
 
 public extension ServiceModelCodeGenerator where TargetSupportType: ModelTargetSupport & ClientTargetSupport {
     func generateAWSClient<DelegateType: ModelClientDelegate>(delegate: DelegateType, fileType: ClientFileType)
-    where DelegateType.TargetSupportType == TargetSupportType {
+    where DelegateType.TargetSupportType == TargetSupportType, DelegateType.ModelType == ModelType {
         let defaultTraceContextType = DefaultTraceContextType(typeName: "AWSClientInvocationTraceContext",
                                                               importTargetName: "AWSHttp")
         generateClient(delegate: delegate, fileType: fileType, defaultTraceContextType: defaultTraceContextType)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Use model type specific ModelOverride types. Required due the underlying changes made in https://github.com/amzn/service-model-swift-code-generate/pull/68


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
