### PR TITLE
Add the ability to generate Swift Concurrency implementations.

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -5,19 +5,33 @@ on:
     branches: [ main, smoke-aws-generate-2.x, smoke-aws-generate-1.x ]
   pull_request:
     branches: [ main, smoke-aws-generate-2.x, smoke-aws-generate-1.x ]
-      
+     
 jobs:
   Build:
     name: Swift ${{ matrix.swift }} on ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-20.04]
-        swift: ["5.5", "5.4.3", "5.3.3", "5.2.5"]
+        os: [ubuntu-22.04]
+        swift: ["5.7.2"]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: marcprux/setup-swift@a990bc57c514a77d232b645843ade099af21aa5e
+      - uses: swift-actions/setup-swift@v1.21.0
         with:
           swift-version: ${{ matrix.swift }}
       - uses: actions/checkout@v2
       - name: Build
-        run: swift build
+        run: swift build -c release
+  Build20:
+    name: Swift ${{ matrix.swift }} on ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-20.04]
+        swift: ["5.6.3", "5.5.3"]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: swift-actions/setup-swift@v1.21.0
+        with:
+          swift-version: ${{ matrix.swift }}
+      - uses: actions/checkout@v2
+      - name: Build
+        run: swift build -c release 

--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/amzn/service-model-swift-code-generate.git",
         "state": {
           "branch": null,
-          "revision": "2693c4d851d1359cd62e7d791546a86bf5bde583",
-          "version": "2.4.0"
+          "revision": "40631a9fbcab5b7ac889b3d891923410a428d364",
+          "version": "2.6.0"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -35,7 +35,7 @@ let package = Package(
             targets: ["CoralToJSONServiceModel"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/amzn/service-model-swift-code-generate.git", from: "2.4.0"),
+        .package(url: "https://github.com/amzn/service-model-swift-code-generate.git", from: "2.6.0"),
     ],
     targets: [
         .target(

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 <img src="https://github.com/amzn/smoke-aws-generate/actions/workflows/swift.yml/badge.svg?branch=smoke-aws-generate-2.x" alt="Build - smoke-aws-generate-2.x Branch">
 </a>
 <a href="http://swift.org">
-<img src="https://img.shields.io/badge/swift-5.2|5.3|5.4|5.5-orange.svg?style=flat" alt="Swift 5.2, 5.3, 5.4 and 5.5 Tested">
+<img src="https://img.shields.io/badge/swift-5.5|5.6|5.7-orange.svg?style=flat" alt="Swift 5.5, 5.6 and 5.7 Tested">
 </a>
 <a href="https://gitter.im/SmokeServerSide">
 <img src="https://img.shields.io/badge/chat-on%20gitter-ee115e.svg?style=flat" alt="Join the Smoke Server Side community on gitter">

--- a/Sources/SmokeAWSGenerate/main.swift
+++ b/Sources/SmokeAWSGenerate/main.swift
@@ -36,7 +36,7 @@ struct CommonConfiguration {
 }
 
 var isUsage = CommandLine.arguments.count == 2 && CommandLine.arguments[1] == "--help"
-let goRepositoryTag = "v1.44.60"
+let goRepositoryTag = "v1.44.114"
 
 let fileHeader = """
     // Copyright 2018-2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
@@ -138,7 +138,7 @@ func getPackageTargetEntriesPackageFile(name: String) -> String {
 func generatePackageFile(baseNames: [String]) -> String {
     
     var packageFileContents = """
-        // swift-tools-version:5.2
+        // swift-tools-version:5.5
         //
         \(fileHeader)
         
@@ -177,6 +177,7 @@ func generatePackageFile(baseNames: [String]) -> String {
                 .package(url: "https://github.com/apple/swift-metrics.git", "1.0.0"..<"3.0.0"),
                 .package(url: "https://github.com/LiveUI/XMLCoding.git", from: "0.4.1"),
                 .package(url: "https://github.com/amzn/smoke-http.git", from: "2.12.0"),
+                .package(url: "https://github.com/amzn/smoke-aws-support.git", from: "1.0.0"),
                 .package(url: "https://github.com/apple/swift-crypto.git", from: "1.0.0"),
             ],
             targets: [\n
@@ -193,6 +194,8 @@ func generatePackageFile(baseNames: [String]) -> String {
                         .product(name: "Metrics", package: "swift-metrics"),
                         .product(name: "XMLCoding", package: "XMLCoding"),
                         .product(name: "SmokeHTTPClient", package: "smoke-http"),
+                        .product(name: "AWSCore", package: "smoke-aws-support"),
+                        .product(name: "AWSLogging", package: "smoke-aws-support"),
                     ]),
                 .target(
                     name: "SmokeAWSHttp", dependencies: [
@@ -205,6 +208,7 @@ func generatePackageFile(baseNames: [String]) -> String {
                         .product(name: "HTTPPathCoding", package: "smoke-http"),
                         .product(name: "HTTPHeadersCoding", package: "smoke-http"),
                         .product(name: "Crypto", package: "swift-crypto"),
+                        .product(name: "AWSHttp", package: "smoke-aws-support"),
                     ]),
                 .target(
                     name: "_SmokeAWSHttpConcurrency", dependencies: [

--- a/Sources/SmokeAWSModelGenerate/APIGatewayClientDelegate.swift
+++ b/Sources/SmokeAWSModelGenerate/APIGatewayClientDelegate.swift
@@ -159,6 +159,21 @@ public struct APIGatewayClientDelegate: ModelClientDelegate {
                         retryConfiguration: retryConfiguration,
                         retryOnError: retryOnErrorProvider)
                     """
+            case .asyncFunction:
+                return """
+                    do {
+                        return try await \(httpClientName).executeRetriableWithOutput(
+                            endpointPath: "/\\(stage)" + \(baseName)ModelOperations.\(functionName).operationPath,
+                            httpMethod: .\(httpVerb),
+                            input: requestInput,
+                            invocationContext: invocationContext,
+                            retryConfiguration: retryConfiguration,
+                            retryOnError: retryOnErrorProvider)
+                    } catch {
+                        let typedError: \(baseName)Error = error.asTypedError()
+                        throw typedError
+                    }
+                    """
             }
         } else {
             switch invokeType {
@@ -187,6 +202,21 @@ public struct APIGatewayClientDelegate: ModelClientDelegate {
                         invocationContext: invocationContext,
                         retryConfiguration: retryConfiguration,
                         retryOnError: retryOnErrorProvider)
+                    """
+            case .asyncFunction:
+                return """
+                    do {
+                        try await \(httpClientName).executeRetriableWithoutOutput(
+                            endpointPath: "/\\(stage)" + \(baseName)ModelOperations.\(functionName).operationPath,
+                            httpMethod: .\(httpVerb),
+                            input: requestInput,
+                            invocationContext: invocationContext,
+                            retryConfiguration: retryConfiguration,
+                            retryOnError: retryOnErrorProvider)
+                        } catch {
+                            let typedError: \(baseName)Error = error.asTypedError()
+                            throw typedError
+                        }
                     """
             }
         }

--- a/Sources/SmokeAWSModelGenerate/AWSClientDelegate+addAWSClientOperationBody.swift
+++ b/Sources/SmokeAWSModelGenerate/AWSClientDelegate+addAWSClientOperationBody.swift
@@ -114,6 +114,21 @@ internal extension AWSClientDelegate {
                 retryConfiguration: retryConfiguration,
                 retryOnError: retryOnErrorProvider)
             """
+        case .asyncFunction:
+            return """
+            do {
+                return try await \(httpClientName).executeRetriableWithOutput(
+                    endpointPath: "\(http.url)",
+                    httpMethod: .\(http.verb),
+                    input: requestInput,
+                    invocationContext: invocationContext,
+                    retryConfiguration: retryConfiguration,
+                    retryOnError: retryOnErrorProvider)
+            } catch {
+                let typedError: \(baseName)Error = error.asTypedError()
+                throw typedError
+            }
+            """
         }
     }
     
@@ -147,6 +162,21 @@ internal extension AWSClientDelegate {
                 invocationContext: invocationContext,
                 retryConfiguration: retryConfiguration,
                 retryOnError: retryOnErrorProvider)
+            """
+        case .asyncFunction:
+            return """
+            do {
+                try await \(httpClientName).executeRetriableWithoutOutput(
+                    endpointPath: "\(http.url)",
+                    httpMethod: .\(http.verb),
+                    input: requestInput,
+                    invocationContext: invocationContext,
+                    retryConfiguration: retryConfiguration,
+                    retryOnError: retryOnErrorProvider)
+            } catch {
+                let typedError: \(baseName)Error = error.asTypedError()
+                throw typedError
+            }
             """
         }
     }

--- a/Sources/SmokeAWSModelGenerate/AWSClientDelegate+addAWSClientQueryOperationBody.swift
+++ b/Sources/SmokeAWSModelGenerate/AWSClientDelegate+addAWSClientQueryOperationBody.swift
@@ -116,6 +116,21 @@ internal extension AWSClientDelegate {
                 retryConfiguration: retryConfiguration,
                 retryOnError: retryOnErrorProvider)
             """
+        case .asyncFunction:
+            return """
+            do {
+                return try await \(httpClientName).executeRetriableWithOutput(
+                    endpointPath: "\(http.url)",
+                    httpMethod: .\(http.verb),
+                    input: requestInput,
+                    invocationContext: invocationContext,
+                    retryConfiguration: retryConfiguration,
+                    retryOnError: retryOnErrorProvider)
+            } catch {
+                let typedError: \(baseName)Error = error.asTypedError()
+                throw typedError
+            }
+            """
         }
     }
     
@@ -149,6 +164,21 @@ internal extension AWSClientDelegate {
                 invocationContext: invocationContext,
                 retryConfiguration: retryConfiguration,
                 retryOnError: retryOnErrorProvider)
+            """
+        case .asyncFunction:
+            return """
+            do {
+                try await \(httpClientName).executeRetriableWithoutOutput(
+                    endpointPath: "\(http.url)",
+                    httpMethod: .\(http.verb),
+                    input: requestInput,
+                    invocationContext: invocationContext,
+                    retryConfiguration: retryConfiguration,
+                    retryOnError: retryOnErrorProvider)
+            } catch {
+                let typedError: \(baseName)Error = error.asTypedError()
+                throw typedError
+            }
             """
         }
     }

--- a/Sources/SmokeAWSModelGenerate/ServiceModelCodeGenerator+generateProtocolAsyncExtensions.swift
+++ b/Sources/SmokeAWSModelGenerate/ServiceModelCodeGenerator+generateProtocolAsyncExtensions.swift
@@ -165,7 +165,7 @@ public extension ServiceModelCodeGenerator {
         fileBuilder.incIndent()
         
         fileBuilder.appendLine("""
-            return try await withUnsafeThrowingContinuation { cont in
+            return try await withCheckedThrowingContinuation { cont in
             """)
         fileBuilder.incIndent()
         

--- a/Sources/SmokeAWSModelGenerate/SmokeAWSModelGenerate.swift
+++ b/Sources/SmokeAWSModelGenerate/SmokeAWSModelGenerate.swift
@@ -57,12 +57,20 @@ extension ServiceModelCodeGenerator {
         
         let clientProtocolDelegate = ClientProtocolDelegate(
             baseName: applicationDescription.baseName)
+        let clientProtocolDelegateV2 = ClientProtocolDelegate(
+            baseName: applicationDescription.baseName, protocolAPIShape: .structuredConcurrency)
         let mockClientDelegate = MockClientDelegate(
             baseName: applicationDescription.baseName,
             isThrowingMock: false)
+        let mockClientDelegateV2 = MockClientDelegate(
+            baseName: applicationDescription.baseName,
+            isThrowingMock: false, clientAPIShape: .structuredConcurrency)
         let throwingClientDelegate = MockClientDelegate(
             baseName: applicationDescription.baseName,
             isThrowingMock: true)
+        let throwingClientDelegateV2 = MockClientDelegate(
+            baseName: applicationDescription.baseName,
+            isThrowingMock: true, clientAPIShape: .structuredConcurrency)
         let awsClientDelegate = AWSClientDelegate(
             baseName: applicationDescription.baseName,
             clientAttributes: awsClientAttributes,
@@ -73,9 +81,12 @@ extension ServiceModelCodeGenerator {
                                                             baseName: applicationDescription.baseName)
         
         generateClient(delegate: clientProtocolDelegate, isGenerator: false)
+        generateClient(delegate: clientProtocolDelegateV2, isGenerator: false, clientAPISupport: .structuredConcurrency)
         generateClient(delegate: mockClientDelegate, isGenerator: false)
         generateClient(delegate: throwingClientDelegate, isGenerator: false)
-        generateClient(delegate: awsClientDelegate, isGenerator: false)
+        generateClient(delegate: mockClientDelegateV2, isGenerator: false, clientAPISupport: .structuredConcurrency)
+        generateClient(delegate: throwingClientDelegateV2, isGenerator: false, clientAPISupport: .structuredConcurrency)
+                generateClient(delegate: awsClientDelegate, isGenerator: false, clientAPISupport: [.syncAndCallback, .structuredConcurrency])
         generateClient(delegate: awsClientDelegate, isGenerator: true)
         generateProtocolAsyncExtensions()
         generateModelOperationsEnum()


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Adds support for Swift Concurrency based implementations in a backwards-compatible manner.

These changes only relate to the `smoke-aws-generate-2.x` branch - which is only used to generate the `smoke-aws` package result in

https://github.com/amzn/smoke-aws/compare/main...on_swift_concurrency_threads

**(baseName)ClientProtocolV2**: a new protocol that just contains Swift Concurrency (Async/Await) based APIs
**(baseName)ClientProtocol**: an existing protocol that now conforms to the new `(baseName)ClientProtocolV2` protocol. There are no other changes to this protocol.
**(baseName)ClientProtocol+async**: existing extensions to the existing `(baseName)ClientProtocol` that provide Swift Concurrency (Async/Await) based APIs by delegating to the callback-based async APIs in the existing protocol. There are no changes to these extensions but they will now satisfy the conformance to the `(baseName)ClientProtocolV2` by providing a *default* implementation unless a conforming type provides one itself.
**AWS(baseName)Client**: an existing type that conforms to the `(baseName)ClientProtocol`, adding Swift Concurrency based implementations that call into the Swift Concurrency based APIs of `smoke-http`. Because these APIs are now implemented within this type, they will *override the default* implementations in the extension of the protocol.
**Mock(baseName)ClientV2** and **Throwing(baseName)ClientV2**: Mock implementations that conform to the `(baseName)ClientProtocolV2` protocol. These implementations just provide the ability to mock the Swift Concurrency (Async/Await) based APIs and therefore do not require passing an `EventLoop` to their initializer.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.