### PR TITLE
Correct timestamp type for ECR models

### DIFF
--- a/Sources/SmokeAWSGenerate/ECRConfiguration.swift
+++ b/Sources/SmokeAWSGenerate/ECRConfiguration.swift
@@ -23,7 +23,7 @@ internal struct ECRConfiguration {
     static let modelOverride = ModelOverride(
         enumerations: EnumerationNaming(usingUpperCamelCase: ["ImageFailureCode", "LayerFailureCode"]),
         fieldRawTypeOverride:
-            [Fields.timestamp.typeDescription: CommonConfiguration.longDateOverride])
+            [Fields.timestamp.typeDescription: CommonConfiguration.integerDateOverride])
     
     static let httpClientConfiguration = HttpClientConfiguration(
         retryOnUnknownError: true,

--- a/Sources/SmokeAWSGenerate/main.swift
+++ b/Sources/SmokeAWSGenerate/main.swift
@@ -176,7 +176,7 @@ func generatePackageFile(baseNames: [String]) -> String {
                 .package(url: "https://github.com/apple/swift-log", from: "1.0.0"),
                 .package(url: "https://github.com/apple/swift-metrics.git", "1.0.0"..<"3.0.0"),
                 .package(url: "https://github.com/LiveUI/XMLCoding.git", from: "0.4.1"),
-                .package(url: "https://github.com/amzn/smoke-http.git", from: "2.12.0"),
+                .package(url: "https://github.com/amzn/smoke-http.git", from: "2.19.1"),
                 .package(url: "https://github.com/amzn/smoke-aws-support.git", from: "1.0.0"),
                 .package(url: "https://github.com/apple/swift-crypto.git", from: "1.0.0"),
             ],


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Correct timestamp type for ECR models. Verified timestamps from the ECR service are returned as doubles rather than longs.

For example

```
imagePushedAt":1.688712875E9
```


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
