### PR TITLE
Update openapi-swift-code-generate to 2.0

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/amzn/openapi-swift-code-generate.git",
       "state" : {
-        "revision" : "9ac750f50061f9046d6dbdf71fe064234f4ed099",
-        "version" : "1.0.1"
+        "revision" : "c89614f73d55fb76d7e9d7c52149e86f61cd4a6b",
+        "version" : "2.0.0"
       }
     },
     {
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/mattpolzin/OpenAPIKit.git",
       "state" : {
-        "revision" : "d40e6c3d57b1b27ac2114861d5a83cf8ee9d206d",
-        "version" : "3.0.0-alpha.6"
+        "revision" : "e805233e54afd394937cecb0a28e575b3388f60f",
+        "version" : "3.0.0-alpha.9"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -49,7 +49,7 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/amzn/service-model-swift-code-generate.git", from: "3.0.0"),
         .package(url: "https://github.com/apple/swift-argument-parser", from: "1.0.0"),
-        .package(url: "https://github.com/amzn/openapi-swift-code-generate.git", from: "1.0.0"),
+        .package(url: "https://github.com/amzn/openapi-swift-code-generate.git", from: "2.0.0"),
     ],
     targets: [
         .plugin(


### PR DESCRIPTION
Update openapi-swift-code-generate to 2.0.0 and OpenAPIKit to 3.0.0-alpha.9

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
