### PR TITLE
Convert HTTPError.deserializationError into a service-specific one

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -23,8 +23,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/amzn/service-model-swift-code-generate.git",
       "state" : {
-        "revision" : "b9d45b4d05196c26247d4bd3aca83c1e53eed72c",
-        "version" : "3.0.2"
+        "revision" : "2f4352075991d3f9b4b1a9a1075bf5e142e5a39e",
+        "version" : "3.1.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -47,7 +47,7 @@ let package = Package(
             targets: ["APIGatewaySwiftGenerateClient"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/amzn/service-model-swift-code-generate.git", from: "3.0.0"),
+        .package(url: "https://github.com/amzn/service-model-swift-code-generate.git", from: "3.1.0"),
         .package(url: "https://github.com/apple/swift-argument-parser", from: "1.0.0"),
         .package(url: "https://github.com/amzn/openapi-swift-code-generate.git", from: "1.0.0"),
     ],


### PR DESCRIPTION

*Issue #, if available:*

*Description of changes:* Convert HTTPError.deserializationError into a service-specific UnmodeledError.deserializationError for additional context.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
