### PR TITLE
Added EventBridge Scheduler with model release v1.46.5 (2023-10-26)

### DIFF
--- a/Sources/SmokeAWSGenerate/SchedulerConfiguration.swift
+++ b/Sources/SmokeAWSGenerate/SchedulerConfiguration.swift
@@ -1,0 +1,40 @@
+// Copyright 2019-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// A copy of the License is located at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// SchedulerConfiguration.swift
+// SmokeAWSGenerate
+//
+
+import Foundation
+import ServiceModelEntities
+
+private let errorTypeHTTPHeaderName = "x-amzn-ErrorType"
+
+internal struct SchedulerConfiguration {
+    static let modelOverride = ModelOverride()
+
+    static let httpClientConfiguration = HttpClientConfiguration(
+        retryOnUnknownError: true,
+        knownErrorsDefaultRetryBehavior: .fail,
+        unretriableUnknownErrors: [],
+        retriableUnknownErrors: [],
+        clientDelegateParameters: ["errorTypeHTTPHeader: \"\(errorTypeHTTPHeaderName)\""])
+
+    static let serviceModelDetails = ServiceModelDetails(
+        serviceName: "scheduler",
+        serviceVersion: "2021-06-30",
+        baseName: "Scheduler",
+        modelOverride: modelOverride,
+        httpClientConfiguration: httpClientConfiguration,
+        signAllHeaders: false)
+}

--- a/Sources/SmokeAWSGenerate/main.swift
+++ b/Sources/SmokeAWSGenerate/main.swift
@@ -36,7 +36,7 @@ struct CommonConfiguration {
 }
 
 var isUsage = CommandLine.arguments.count == 2 && CommandLine.arguments[1] == "--help"
-let goRepositoryTag = "v1.44.174"
+let goRepositoryTag = "v1.46.5"
 
 let fileHeader = """
     // Copyright 2018-2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
@@ -386,6 +386,7 @@ func handleApplication() throws {
         //CodeBuildConfiguration.serviceModelDetails,
         CodePipelineConfiguration.serviceModelDetails,
         ECRConfiguration.serviceModelDetails,
+        SchedulerConfiguration.serviceModelDetails,
         AppConfigConfiguration.serviceModelDetails]
     
     var baseFilePath: String?


### PR DESCRIPTION
*Issue #, if available:*

No issue. Added EventBridge Scheduler. Update to the latest because current model did not yet support automatic schedule deletion (https://github.com/aws/aws-sdk-go/blob/886c1752c1f070abab22aea4c2b6e17aa7090b04/models/apis/scheduler/2021-06-30/api-2.json#L325C67-L325C67)

*Description of changes:*

I will submit a matching PR to smoke-aws.

*Testing:*

Created a test schedule:

```
2023-10-26T23:08:24-0400 trace: outgoingEndpoint=https://scheduler.us-west-2.amazonaws.com:443/schedules/test-schedule outgoingRequestId=9E7E2E84-168A-42F1-A5D2-5E576AC7BBD7 [SmokeHTTPClient] Sending POST request to endpoint: https://scheduler.us-west-2.amazonaws.com:443/schedules/test-schedule at path: /schedules/test-schedule.
2023-10-26T23:08:24-0400 trace: outgoingEndpoint=https://scheduler.us-west-2.amazonaws.com:443/schedules/test-schedule outgoingRequestId=9E7E2E84-168A-42F1-A5D2-5E576AC7BBD7 [AWSHttp] Target not found for HTTP header, assigning CreateSchedule to x-amzn-target header.
2023-10-26T23:08:24-0400 trace: bodyData={
  "Description" : "...",
  "FlexibleTimeWindow" : {
    "Mode" : "OFF"
  },
  "ScheduleExpression" : "at(2023-10-27T03:15:00)",
  "Target" : {
    "Arn" : "arn:aws:sqs:us-west-2:AWS_ACCT:knov-test-queue",
    "Input" : "this-is-the-message-to-sqs",
    "RoleArn" : "arn:aws:iam::AWS_ACCT:role\/knov-test-role"
  },
  "ActionAfterCompletion" : "DELETE",
  "ClientToken" : "idempotency-token"
} bodyDataSize=416 method=POST outgoingEndpoint=https://scheduler.us-west-2.amazonaws.com:443/schedules/test-schedule outgoingRequestId=9E7E2E84-168A-42F1-A5D2-5E576AC7BBD7 uri=https://scheduler.us-west-2.amazonaws.com:443/schedules/test-schedule [AWSHttp] Starting outgoing request.
2023-10-26T23:08:25-0400 trace: bodyData={"ScheduleArn":"arn:aws:scheduler:us-west-2:AWS_ACCT:schedule/default/test-schedule"} bodyDataSize=89 code=200 outgoingEndpoint=https://scheduler.us-west-2.amazonaws.com:443/schedules/test-schedule outgoingRequestId=9E7E2E84-168A-42F1-A5D2-5E576AC7BBD7 x-amz-request-id=d8ea794d-0cd4-42aa-b48f-79f04c6e162c [AWSHttp] Successfully completed outgoing request.
2023-10-26T23:08:25-0400 trace: body={"ScheduleArn":"arn:aws:scheduler:us-west-2:AWS_ACCT:schedule/default/test-schedule"} outgoingEndpoint=https://scheduler.us-west-2.amazonaws.com:443/schedules/test-schedule outgoingRequestId=9E7E2E84-168A-42F1-A5D2-5E576AC7BBD7 [AWSHttp] Attempting to decode result data from JSON to CreateScheduleOutput
▿ SchedulerModel.CreateScheduleOutput
  - scheduleArn: "arn:aws:scheduler:us-west-2:AWS_ACCT:schedule/default/test-schedule"
```

Can also see that the errors are handled:

```
2023-10-26T23:10:44-0400 trace: body={
  "__type" : "ConflictException",
  "Message" : "Schedule test-schedule already exists."
} outgoingEndpoint=https://scheduler.us-west-2.amazonaws.com:443/schedules/test-schedule outgoingRequestId=F01EA6F5-CB94-4890-9E86-26E584A8279D [AWSHttp] Attempting to decode error data from JSON to SchedulerError.
2023-10-26T23:10:44-0400 trace: bodyData={"Message":"Schedule test-schedule already exists."} bodyDataSize=52 code=409 error=HTTPClientError(responseCode: 409, cause: SchedulerModel.SchedulerError.conflict(SchedulerModel.ConflictException(message: "Schedule test-schedule already exists."))) outgoingEndpoint=https://scheduler.us-west-2.amazonaws.com:443/schedules/test-schedule outgoingRequestId=F01EA6F5-CB94-4890-9E86-26E584A8279D x-amz-request-id=4e484533-7959-4b17-ac7a-860b137e87cb [AWSHttp] Unsuccessfully completed outgoing request.
2023-10-26T23:10:44-0400 trace: outgoingEndpoint=https://scheduler.us-west-2.amazonaws.com:443/schedules/test-schedule outgoingRequestId=F01EA6F5-CB94-4890-9E86-26E584A8279D [SmokeHTTPClient] Request not retried due to error returned: HTTPClientError(responseCode: 409, cause: SchedulerModel.SchedulerError.conflict(SchedulerModel.ConflictException(message: "Schedule test-schedule already exists.")))
BackfillPASCAEManifestsAndRefreshBoundaryReports terminated with an error.
▿ SchedulerModel.SchedulerError.conflict
  ▿ conflict: SchedulerModel.ConflictException
    - message: "Schedule test-schedule already exists."
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
