### PR TITLE
Use the AWSClientInvocationDelegate factory function

### DIFF
--- a/Sources/SmokeAWSGenerate/main.swift
+++ b/Sources/SmokeAWSGenerate/main.swift
@@ -177,7 +177,7 @@ func generatePackageFile(baseNames: [String]) -> String {
                 .package(url: "https://github.com/apple/swift-metrics.git", "1.0.0"..<"3.0.0"),
                 .package(url: "https://github.com/LiveUI/XMLCoding.git", from: "0.4.1"),
                 .package(url: "https://github.com/amzn/smoke-http.git", from: "2.19.1"),
-                .package(url: "https://github.com/amzn/smoke-aws-support.git", from: "1.0.0"),
+                .package(url: "https://github.com/amzn/smoke-aws-support.git", from: "1.7.0"),
                 .package(url: "https://github.com/apple/swift-crypto.git", from: "1.0.0"),
             ],
             targets: [\n

--- a/Sources/SmokeAWSModelGenerate/AWSClientDelegate+addAWSClientOperationBody.swift
+++ b/Sources/SmokeAWSModelGenerate/AWSClientDelegate+addAWSClientOperationBody.swift
@@ -30,9 +30,19 @@ internal extension AWSClientDelegate {
         fileBuilder.incIndent()
         
         let typeName = function.name.getNormalizedTypeName(forModel: codeGenerator.model)
+                
+        let initializerPrefix: String
+        let initializerPostfix: String
+        if case .asyncFunction = invokeType {
+            initializerPrefix = "try await "
+            initializerPostfix = ".get"
+        } else {
+            initializerPrefix = ""
+            initializerPostfix = ""
+        }
         
         fileBuilder.appendLine("""
-            let handlerDelegate = AWSClientInvocationDelegate(
+            let handlerDelegate = \(initializerPrefix)AWSClientInvocationDelegate\(initializerPostfix)(
                         credentialsProvider: credentialsProvider,
                         awsRegion: awsRegion,
                         service: service,

--- a/Sources/SmokeAWSModelGenerate/AWSClientDelegate+addAWSClientQueryOperationBody.swift
+++ b/Sources/SmokeAWSModelGenerate/AWSClientDelegate+addAWSClientQueryOperationBody.swift
@@ -39,8 +39,18 @@ internal extension AWSClientDelegate {
             wrappedTypeDeclaration = "NoHTTPRequestInput(encodable: input)"
         }
         
+        let initializerPrefix: String
+        let initializerPostfix: String
+        if case .asyncFunction = invokeType {
+            initializerPrefix = "try await "
+            initializerPostfix = ".get"
+        } else {
+            initializerPrefix = ""
+            initializerPostfix = ""
+        }
+        
         fileBuilder.appendLine("""
-            let handlerDelegate = AWSClientInvocationDelegate(
+            let handlerDelegate = \(initializerPrefix)AWSClientInvocationDelegate\(initializerPostfix)(
                         credentialsProvider: credentialsProvider,
                         awsRegion: awsRegion,
                         service: service,


### PR DESCRIPTION

*Issue #, if available:*

*Description of changes:* Use the AWSClientInvocationDelegate factory function for structured concurrency implementations. This will construct the AWSClientInvocationDelegate instance appropriately for the credentials provider instance passed, using credentials from the `CredentialsProviderV2` if available.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
