### PR TITLE
Update CloudWatch client to send payload in POST body instead of URL

### DIFF
--- a/Sources/SmokeAWSGenerate/CloudwatchConfiguration.swift
+++ b/Sources/SmokeAWSGenerate/CloudwatchConfiguration.swift
@@ -17,21 +17,27 @@
 
 import Foundation
 import ServiceModelEntities
+import SmokeAWSModelGenerate
 
 internal struct CloudwatchConfiguration {
-    static let modelOverride = ModelOverride(fieldRawTypeOverride: ["Long": CommonConfiguration.intOverride])
-    
+    static let modelOverride = ModelOverride(
+        fieldRawTypeOverride: ["Long": CommonConfiguration.intOverride],
+        additionalErrors: ["ThrottlingException"])
+
     static let httpClientConfiguration = HttpClientConfiguration(
         retryOnUnknownError: true,
         knownErrorsDefaultRetryBehavior: .fail,
         unretriableUnknownErrors: [],
-        retriableUnknownErrors: ["LimitExceededFault", "LimitExceededException"],
+        retriableUnknownErrors: ["LimitExceededFault", "LimitExceededException", "ThrottlingException"],
+        clientDelegateNameOverride: "FormEncodedXMLAWSHttpClientDelegate",
         clientDelegateParameters: ["outputListDecodingStrategy: .collapseListUsingItemTag(\"member\")",
                                    "inputQueryListEncodingStrategy: .expandListWithIndexAndItemTag(itemTag: \"member\")"])
-    
+
     static let serviceModelDetails = ServiceModelDetails(
         serviceName: "monitoring", serviceVersion: "2010-08-01",
         baseName: "CloudWatch", modelOverride: modelOverride,
         httpClientConfiguration: httpClientConfiguration,
-        signAllHeaders: false)
+        signAllHeaders: false,
+        awsCodeGenerationCustomizations: AWSCodeGenerationCustomizations(
+            contentTypeHeaderOverride: "application/x-www-form-urlencoded; charset=utf-8"))
 }


### PR DESCRIPTION
*Issue #, if available:*
URL encoded requests do not support as much as data as POST body. This will allow client to send up to 1MB of data to CloudWatch service.

*Description of changes:*
This update to the client changes where the payload is placed in the HTTP request. Currently it's in the URL. After this change it will be in POST body.

*Testing:*

Before (URL encoded):

```
2024-01-25T13:23:46-0500 trace cw : outgoingEndpoint=https://monitoring.us-west-2.amazonaws.com:443/%3FAction=PutMetricData&MetricData.member.1.MetricName=TestMetric&MetricData.member.1.Value=1.0&Namespace=TestNamespace&Version=2010-08-01 outgoingRequestId=883B59FB-E594-4642-8650-38AED81DDDAE [SmokeHTTPClient] Sending POST request to endpoint: https://monitoring.us-west-2.amazonaws.com:443/?Action=PutMetricData&MetricData.member.1.MetricName=TestMetric&MetricData.member.1.Value=1.0&Namespace=TestNamespace&Version=2010-08-01 at path: /?Action=PutMetricData&MetricData.member.1.MetricName=TestMetric&MetricData.member.1.Value=1.0&Namespace=TestNamespace&Version=2010-08-01.
2024-01-25T13:23:46-0500 trace cw : outgoingEndpoint=https://monitoring.us-west-2.amazonaws.com:443/%3FAction=PutMetricData&MetricData.member.1.MetricName=TestMetric&MetricData.member.1.Value=1.0&Namespace=TestNamespace&Version=2010-08-01 outgoingRequestId=883B59FB-E594-4642-8650-38AED81DDDAE [AWSHttp] Operation not found for HTTP header for monitoring request, no headers needed for signing.
2024-01-25T13:23:46-0500 trace cw : bodyData= bodyDataSize=0 method=POST outgoingEndpoint=https://monitoring.us-west-2.amazonaws.com:443/%3FAction=PutMetricData&MetricData.member.1.MetricName=TestMetric&MetricData.member.1.Value=1.0&Namespace=TestNamespace&Version=2010-08-01 outgoingRequestId=883B59FB-E594-4642-8650-38AED81DDDAE uri=https://monitoring.us-west-2.amazonaws.com:443/?Action=PutMetricData&MetricData.member.1.MetricName=TestMetric&MetricData.member.1.Value=1.0&Namespace=TestNamespace&Version=2010-08-01 [AWSHttp] Starting outgoing request.
2024-01-25T13:23:46-0500 trace cw : bodyData=<PutMetricDataResponse xmlns="http://monitoring.amazonaws.com/doc/2010-08-01/">
  <ResponseMetadata>
    <RequestId>75b6e546-1eb5-47bd-b761-98c9ef9bcda2</RequestId>
  </ResponseMetadata>
</PutMetricDataResponse>
 bodyDataSize=212 code=200 outgoingEndpoint=https://monitoring.us-west-2.amazonaws.com:443/%3FAction=PutMetricData&MetricData.member.1.MetricName=TestMetric&MetricData.member.1.Value=1.0&Namespace=TestNamespace&Version=2010-08-01 outgoingRequestId=883B59FB-E594-4642-8650-38AED81DDDAE x-amz-request-id=75b6e546-1eb5-47bd-b761-98c9ef9bcda2 [AWSHttp] Successfully completed outgoing request.

```

After (POST body):

```
2024-01-25T13:35:24-0500 trace cw : outgoingEndpoint=https://monitoring.us-west-2.amazonaws.com:443/ outgoingRequestId=64402B61-3F8F-4863-BAFD-9C8C3DBEE86F [SmokeHTTPClient] Sending POST request to endpoint: https://monitoring.us-west-2.amazonaws.com:443/ at path: /.
2024-01-25T13:35:24-0500 trace cw : outgoingEndpoint=https://monitoring.us-west-2.amazonaws.com:443/ outgoingRequestId=64402B61-3F8F-4863-BAFD-9C8C3DBEE86F [AWSHttp] Operation not found for HTTP header for monitoring request, no headers needed for signing.
2024-01-25T13:35:24-0500 trace cw : bodyData=Action=PutMetricData&MetricData.member.1.MetricName=TestMetric&MetricData.member.1.Value=3.0&Namespace=TestNamespace&Version=2010-08-01 bodyDataSize=135 method=POST outgoingEndpoint=https://monitoring.us-west-2.amazonaws.com:443/ outgoingRequestId=64402B61-3F8F-4863-BAFD-9C8C3DBEE86F uri=https://monitoring.us-west-2.amazonaws.com:443/ [AWSHttp] Starting outgoing request.
2024-01-25T13:35:24-0500 trace cw : bodyData=<PutMetricDataResponse xmlns="http://monitoring.amazonaws.com/doc/2010-08-01/">
  <ResponseMetadata>
    <RequestId>d69aff2b-cd13-462a-ab05-0e3b2de7741a</RequestId>
  </ResponseMetadata>
</PutMetricDataResponse>
 bodyDataSize=212 code=200 outgoingEndpoint=https://monitoring.us-west-2.amazonaws.com:443/ outgoingRequestId=64402B61-3F8F-4863-BAFD-9C8C3DBEE86F x-amz-request-id=d69aff2b-cd13-462a-ab05-0e3b2de7741a [AWSHttp] Successfully completed outgoing request.
```

Verified that the metric appears using AWS console.

PR for the generated code: https://github.com/amzn/smoke-aws/pull/146

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
