### PR TITLE
Update SwaggerParser repository location because original is 404

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -6,13 +6,13 @@
         "repositoryURL": "https://github.com/amzn/service-model-swift-code-generate.git",
         "state": {
           "branch": null,
-          "revision": "40631a9fbcab5b7ac889b3d891923410a428d364",
-          "version": "2.6.0"
+          "revision": "5a6882138c61f23fc343405e8ad70c8b71b5c219",
+          "version": "2.6.1"
         }
       },
       {
         "package": "SwaggerParser",
-        "repositoryURL": "https://github.com/tachyonics/SwaggerParser.git",
+        "repositoryURL": "https://github.com/knovichikhin/SwaggerParser.git",
         "state": {
           "branch": null,
           "revision": "c0eb70485c59a9d7dd6765dcd303b49fdb3040ee",

--- a/Package.swift
+++ b/Package.swift
@@ -35,7 +35,7 @@ let package = Package(
             targets: ["CoralToJSONServiceModel"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/amzn/service-model-swift-code-generate.git", from: "2.6.0"),
+        .package(url: "https://github.com/amzn/service-model-swift-code-generate.git", from: "2.6.1"),
     ],
     targets: [
         .target(


### PR DESCRIPTION
*Issue #, if available:*
 Update SwaggerParser repository location because original is 404

*Description of changes:*
Update service-model-swift-code-generate to update SwaggerParser.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
